### PR TITLE
Tweak E2E test infra

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: self-hosted
     env:
       BUILD_DIR: tmp/pr_builds/PR_${{ github.event.number }}/${{ github.run_id }}
-      DOCKER_PROJECT_NAME: backend-unit-tests-${{ github.event.number }}-${{ github.run_id }}
+      DOCKER_PROJECT_NAME: pr-tests-${{ github.event.number }}-${{ github.run_id }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,15 +23,12 @@ jobs:
         working-directory: ${{ env.BUILD_DIR }}
         run: make e2e_tests
 
-      - name: Cleanup Docker Resources - Docker Compose Down
+      - name: Cleanup Docker Project Resources
         if: always()
         working-directory: ${{ env.BUILD_DIR }}
-        run: docker compose -p ${{ env.DOCKER_PROJECT_NAME }} -f compose.testing.yml down --volumes
-
-      - name: Cleanup Docker Resources - Images
-        if: always()
-        working-directory: ${{ env.BUILD_DIR }}
-        run: docker images --filter "label=com.docker.compose.project=${{ env.DOCKER_PROJECT_NAME }}" -q | xargs -r docker rmi -f
+        run: |
+          docker compose -p ${{ env.DOCKER_PROJECT_NAME }} -f compose.testing.yml down --volumes
+          docker images --filter "label=com.docker.compose.project=${{ env.DOCKER_PROJECT_NAME }}" -q | xargs -r docker rmi -f
 
       - name: Cleanup Files
         if: always()

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -17,11 +17,11 @@ jobs:
 
       - name: Backend Unit Tests with Docker
         working-directory: ${{ env.BUILD_DIR }}
-        run: make backend_tests PROJECT_NAME=${{ env.DOCKER_PROJECT_NAME }}
+        run: make backend_tests
 
       - name: Playwright E2E Tests with Docker
         working-directory: ${{ env.BUILD_DIR }}
-        run: make e2e_tests PROJECT_NAME=${{ env.DOCKER_PROJECT_NAME }}
+        run: make e2e_tests
 
       - name: Cleanup Docker Resources - Docker Compose Down
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Define variables for Docker Compose files
-COMPOSE_FILE_DEV=compose.override.yml
+COMPOSE_FILE_BASE=compose.yml
 COMPOSE_FILE_PROD=compose.prod.yml
 COMPOSE_FILE_TEST=compose.testing.yml
 
@@ -32,11 +32,13 @@ prod:
 
 # Run backend tests
 backend_tests:
-	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) run --build backend-unit-tests
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) up --remove-orphans --build backend-unit-tests
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) down --volumes
 
 # Run end-to-end tests
 e2e_tests:
-	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) up --abort-on-container-exit --exit-code-from playwright --build playwright
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) up --remove-orphans --exit-code-from playwright --build playwright
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) down --volumes
 
 # Stop all services and clean up
 down:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ prod:
 
 # Run backend tests
 backend_tests:
-	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) run --remove-orphans --exit-code-from backend-unit-tests --build backend-unit-tests
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) run --remove-orphans --build backend-unit-tests
 	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) down --volumes
 
 # Run end-to-end tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # Define variables for Docker Compose files
-COMPOSE_FILE_BASE=compose.yml
 COMPOSE_FILE_PROD=compose.prod.yml
 COMPOSE_FILE_TEST=compose.testing.yml
 
@@ -32,12 +31,12 @@ prod:
 
 # Run backend tests
 backend_tests:
-	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) up --remove-orphans --build backend-unit-tests
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) run --remove-orphans --exit-code-from backend-unit-tests --build backend-unit-tests
 	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) down --volumes
 
 # Run end-to-end tests
 e2e_tests:
-	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) up --remove-orphans --exit-code-from playwright --build playwright
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) run --remove-orphans --build playwright
 	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) down --volumes
 
 # Stop all services and clean up

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ backend_tests:
 
 # Run end-to-end tests
 e2e_tests:
-	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_DEV) -f $(COMPOSE_FILE_TEST) run --build playwright
+	@docker compose $(PROJECT_FLAG) -f $(COMPOSE_FILE_TEST) up --abort-on-container-exit --exit-code-from playwright --build playwright
 
 # Stop all services and clean up
 down:

--- a/compose.testing.yml
+++ b/compose.testing.yml
@@ -4,6 +4,15 @@ services:
     command: ["uv", "run", "pytest", "tests", "-s"]
   backend:
     build: ./backend
+    environment:
+      - SERVE_STATIC_FILES=true
+    volumes:
+      - frontend_dist:/app/static
+    command: ["fastapi", "run", "--host", "0.0.0.0", "src/nba_wins_pool/main_backend.py"]
+    # environment:
+    #   - CORS_ALLOW_ALL=true
+    # # runs on port 8000 by default
+    # command: ["fastapi", "run", "--host", "0.0.0.0", "src/nba_wins_pool/main_backend.py"]
     healthcheck:
       test: ["CMD", "wget", "--spider", "backend:8000/docs/"]
       interval: 5s
@@ -11,17 +20,30 @@ services:
       retries: 5
   frontend:
     build: ./frontend
-    healthcheck:
-      test: ["CMD", "wget", "--spider", "frontend:5173/"]
-      interval: 5s
-      timeout: 2s
-      retries: 5
+    environment:
+      - VITE_BACKEND_URL=
+      # - VITE_BACKEND_URL=http://backend:8000
+    # runs on port 4173 by default
+    command: ["npm", "run", "build"]
+    volumes:
+      - frontend_dist:/app/dist
+    # healthcheck:
+    #   test: ["CMD", "wget", "--spider", "frontend:4173/"]
+    #   interval: 5s
+    #   timeout: 2s
+    #   retries: 5
   playwright:
     build: ./playwright_tests
+    environment:
+      - BASE_URL=http://backend:8000/
+      # - FRONTEND_BASE_URL=http://frontend:4173/
     ports:
-    - "9323:9323"
+      - "9323:9323"
     depends_on:
-      frontend:
-        condition: service_healthy
+      # frontend:
+      #   condition: service_healthy
       backend:
         condition: service_healthy
+
+volumes:
+  frontend_dist:

--- a/compose.testing.yml
+++ b/compose.testing.yml
@@ -2,6 +2,7 @@ services:
   backend-unit-tests:
     build: ./backend
     command: ["uv", "run", "pytest", "tests", "-s"]
+
   backend:
     build: ./backend
     environment:
@@ -9,39 +10,29 @@ services:
     volumes:
       - frontend_dist:/app/static
     command: ["fastapi", "run", "--host", "0.0.0.0", "src/nba_wins_pool/main_backend.py"]
-    # environment:
-    #   - CORS_ALLOW_ALL=true
-    # # runs on port 8000 by default
-    # command: ["fastapi", "run", "--host", "0.0.0.0", "src/nba_wins_pool/main_backend.py"]
     healthcheck:
-      test: ["CMD", "wget", "--spider", "backend:8000/docs/"]
+      test: ["CMD", "wget", "--spider", "http://backend:8000/favicon.ico"]
       interval: 5s
       timeout: 2s
       retries: 5
-  frontend:
+    depends_on:
+      - frontend-builder
+
+  frontend-builder:
     build: ./frontend
     environment:
       - VITE_BACKEND_URL=
-      # - VITE_BACKEND_URL=http://backend:8000
-    # runs on port 4173 by default
     command: ["npm", "run", "build"]
     volumes:
       - frontend_dist:/app/dist
-    # healthcheck:
-    #   test: ["CMD", "wget", "--spider", "frontend:4173/"]
-    #   interval: 5s
-    #   timeout: 2s
-    #   retries: 5
+
   playwright:
     build: ./playwright_tests
     environment:
       - BASE_URL=http://backend:8000/
-      # - FRONTEND_BASE_URL=http://frontend:4173/
     ports:
       - "9323:9323"
     depends_on:
-      # frontend:
-      #   condition: service_healthy
       backend:
         condition: service_healthy
 

--- a/playwright_tests/playwright.config.ts
+++ b/playwright_tests/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://frontend:5173/',
+    baseURL: process.env.BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',


### PR DESCRIPTION
* testing setup for playwright emulates prod setup where frontend is built and served from the backend
* playwright tests against single backend server
* add docker down to make commands - to avoid issues with running unit tests followed by playwright tests with resources still existing