### PR TITLE
fix: update service file target

### DIFF
--- a/services/github_runner.service
+++ b/services/github_runner.service
@@ -10,4 +10,4 @@ RestartSec=30
 ExecStart=</path/to/actions-runner/run.sh>
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network.target

--- a/services/github_runner.service
+++ b/services/github_runner.service
@@ -10,4 +10,4 @@ RestartSec=30
 ExecStart=</path/to/actions-runner/run.sh>
 
 [Install]
-WantedBy=network.target
+WantedBy=default.target

--- a/services/nbawinspool.service
+++ b/services/nbawinspool.service
@@ -11,4 +11,4 @@ WorkingDirectory=<path/to/github_runner/workdir>/nba-wins-pool/deploy
 ExecStart=make prod
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network.target

--- a/services/nbawinspool.service
+++ b/services/nbawinspool.service
@@ -11,4 +11,4 @@ WorkingDirectory=<path/to/github_runner/workdir>/nba-wins-pool/deploy
 ExecStart=make prod
 
 [Install]
-WantedBy=network.target
+WantedBy=default.target


### PR DESCRIPTION
update service files to request `default.target` instead of `multi-user.target`. When running in user mode, `multi-user.target` does not exist, so switching to `default.target`.

Hopefully this fixes the github runner not starting up at boot.