### PR TITLE
no longer inverting jazz logo colors

### DIFF
--- a/frontend/src/components/pool/LeaderboardTable.vue
+++ b/frontend/src/components/pool/LeaderboardTable.vue
@@ -173,7 +173,6 @@ const dtScrollable = computed(() => !!props.maxHeight)
                   <img
                     :src="slotProps.data.logo_url"
                     class="size-6"
-                    :class="{ invert: slotProps.data.team.toLowerCase() === 'utah jazz' }"
                     :alt="slotProps.data.team"
                   />
                   <p>{{ slotProps.data.team }}</p>


### PR DESCRIPTION
Jazz logo is now purple instead of black, so inverting isn't necessary anymore