### PR TITLE
parse remote scoreboard, add game clock for games in progress

### DIFF
--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -293,10 +293,16 @@ class LeaderboardService:
                 results[home_team] = f"{status_text} vs {away_abbrev}"
                 results[away_team] = f"{status_text} @ {home_abbrev}"
             elif status == NBAGameStatus.INGAME:
+                remaining_time = pd.Timedelta(row["game_clock"])
+                if remaining_time < pd.Timedelta(minutes=1):
+                    clock_str = f"0:{remaining_time.seconds:.1f}"
+                else:
+                    clock_str = f"{remaining_time.seconds // 60}:{remaining_time.seconds % 60:02d}"
+
                 home_score = row["home_score"]
                 away_score = row["away_score"]
-                results[home_team] = f"{home_score}-{away_score}, {status_text} vs {away_abbrev}"
-                results[away_team] = f"{away_score}-{home_score}, {status_text} @ {home_abbrev}"
+                results[home_team] = f"{home_score}-{away_score}, {clock_str} {status_text} vs {away_abbrev}"
+                results[away_team] = f"{away_score}-{home_score}, {clock_str} {status_text} @ {home_abbrev}"
             elif status == NBAGameStatus.FINAL:
                 home_score = row["home_score"]
                 away_score = row["away_score"]

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -86,44 +86,6 @@ class TestGetScoreboardCached:
     """Tests for get_scoreboard_cached method."""
 
     @pytest.mark.asyncio
-    async def test_cache_hit_returns_cached_data(self, nba_service, mock_repo):
-        """Test that valid cached data is returned without fetching from API."""
-        # Arrange
-        today = datetime.now(UTC).date()
-        # Mock raw API response structure
-        cached_data = ExternalData(
-            key=f"nba:scoreboard:{today.isoformat()}",
-            data_format=DataFormat.JSON,
-            data_json={
-                "scoreboard": {
-                    "gameDate": today.isoformat(),
-                    "games": [
-                        {
-                            "gameId": "123",
-                            "homeTeam": {"teamId": 1610612747, "teamTricode": "LAL", "score": 100},
-                            "awayTeam": {"teamId": 1610612738, "teamTricode": "BOS", "score": 95},
-                            "gameStatus": 3,
-                            "gameTimeUTC": "2024-10-22T23:00:00Z",
-                            "gameStatusText": "Final",
-                            "gameLabel": "",
-                        }
-                    ],
-                }
-            },
-            updated_at=datetime.now(UTC),  # Fresh cache
-        )
-        mock_repo.get_by_key.return_value = cached_data
-
-        # Act
-        games, scoreboard_date = await nba_service.get_scoreboard_cached()
-
-        # Assert
-        assert len(games) == 1
-        assert games[0]["game_id"] == "123"
-        assert scoreboard_date == today
-        mock_repo.get_by_key.assert_called_once()
-
-    @pytest.mark.asyncio
     async def test_stale_cache_fetches_fresh_data(self, nba_service, mock_repo, sample_scoreboard_data):
         """Test that stale cached data triggers a fresh API fetch."""
         # Arrange


### PR DESCRIPTION
- Updated cache logic to only compare scoreboard dates and always parse the remote scoreboard.
- Added game clock to string for games in progress


<img width="1491" height="975" alt="image" src="https://github.com/user-attachments/assets/ec3773ac-f8d9-40e8-9b30-254c137b225e" />
