### PR TITLE
fix: schedule service for fetching projections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 .vscode
 **/.DS_Store
 .prof
+.agent/

--- a/backend/src/nba_wins_pool/repositories/nba_projections_repository.py
+++ b/backend/src/nba_wins_pool/repositories/nba_projections_repository.py
@@ -56,6 +56,7 @@ class NBAProjectionsRepository:
                     NBAProjections.source,
                     func.max(NBAProjections.fetched_at).label("latest_fetch"),
                 )
+                .where(NBAProjections.reg_season_wins.is_not(None))
                 .group_by(NBAProjections.team_id, NBAProjections.season, NBAProjections.source)
                 .subquery()
             )

--- a/backend/src/nba_wins_pool/scripts/fetch_nba_projections.py
+++ b/backend/src/nba_wins_pool/scripts/fetch_nba_projections.py
@@ -7,15 +7,8 @@ import asyncio
 import logging
 import sys
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from nba_wins_pool.db.core import engine
-from nba_wins_pool.repositories.external_data_repository import ExternalDataRepository
-from nba_wins_pool.repositories.nba_projections_repository import NBAProjectionsRepository
-from nba_wins_pool.repositories.team_repository import TeamRepository
-from nba_wins_pool.services.nba_data_service import NbaDataService
-from nba_wins_pool.services.nba_espn_projections_service import NBAEspnProjectionsService
-from nba_wins_pool.services.nba_vegas_projections_service import NBAVegasProjectionsService
+from nba_wins_pool.db.core import get_db_session
+from nba_wins_pool.job_definitions import fetch_nba_projections_job
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("fetch_projections")
@@ -26,38 +19,7 @@ async def main():
     logger.info("Starting projections fetch (FanDuel and ESPN)...")
 
     try:
-        async with AsyncSession(engine) as session:
-            # Initialize repositories and services
-            team_repo = TeamRepository(session)
-            external_repo = ExternalDataRepository(session)
-            nba_projections_repo = NBAProjectionsRepository(session)
-            nba_data_service = NbaDataService(session, external_repo)
-
-            # FanDuel (Vegas) service
-            vegas_service = NBAVegasProjectionsService(
-                db_session=session,
-                nba_data_service=nba_data_service,
-                team_repository=team_repo,
-                nba_projections_repository=nba_projections_repo,
-            )
-
-            # ESPN service
-            espn_service = NBAEspnProjectionsService(
-                db_session=session,
-                team_repository=team_repo,
-                nba_projections_repository=nba_projections_repo,
-            )
-
-            # Fetch and write projections
-            vegas_count = await vegas_service.write_projections()
-            espn_count = await espn_service.write_projections()
-
-            # Commit changes
-            await session.commit()
-
-            logger.info(f"FanDuel projections fetch completed. Successfully wrote {vegas_count} records.")
-            logger.info(f"ESPN BPI projections fetch completed. Successfully wrote {espn_count} records.")
-
+        await fetch_nba_projections_job(get_db_session)
     except Exception as e:
         logger.error(f"Failed to fetch projections: {e}", exc_info=True)
         sys.exit(1)

--- a/backend/tests/test_job_definitions.py
+++ b/backend/tests/test_job_definitions.py
@@ -20,23 +20,23 @@ async def test_fetch_nba_projections_job():
         yield mock_db
 
     with (
-        patch("nba_wins_pool.job_definitions.get_nba_vegas_projections_service") as mock_get_vegas,
-        patch("nba_wins_pool.job_definitions.get_nba_espn_projections_service") as mock_get_espn,
+        patch("nba_wins_pool.job_definitions.NBAVegasProjectionsService") as MockVegasService,
+        patch("nba_wins_pool.job_definitions.NBAEspnProjectionsService") as MockEspnService,
     ):
-        mock_vegas_service = MagicMock()
-        mock_vegas_service.write_projections = AsyncMock()
-        mock_get_vegas.return_value = mock_vegas_service
+        mock_vegas_service = MockVegasService.return_value
+        mock_vegas_service.write_projections = AsyncMock(return_value=10)
 
-        mock_espn_service = MagicMock()
-        mock_espn_service.write_projections = AsyncMock()
-        mock_get_espn.return_value = mock_espn_service
+        mock_espn_service = MockEspnService.return_value
+        mock_espn_service.write_projections = AsyncMock(return_value=5)
 
         await fetch_nba_projections_job(mock_factory)
 
-        mock_get_vegas.assert_called_once_with(mock_db)
-        mock_vegas_service.write_projections.assert_called_once()
+        # Verify services were instantiated
+        MockVegasService.assert_called_once()
+        MockEspnService.assert_called_once()
 
-        mock_get_espn.assert_called_once_with(mock_db)
+        # Verify projections were written
+        mock_vegas_service.write_projections.assert_called_once()
         mock_espn_service.write_projections.assert_called_once()
 
 


### PR DESCRIPTION
The background service for fetching projections was not working after the previous round of changes.
Updated the scheduled service to use the working code from the script to fetch projections.

Also updated the logic to make sure regular season wins is populated when fetching the projections in order to compute expected wins.