### PR TITLE
fix: health check definition

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -18,7 +18,7 @@ services:
       - frontend_dist:/app/static
     command: ["fastapi", "run", "--host", "0.0.0.0", "src/nba_wins_pool/main_backend.py"]
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/internal/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
The health check definition for the backend was missing `/internal/` which was causing the container to be considered unhealthy.