### PR TITLE
fix: backend healthcheck - add curl to Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@
 FROM ghcr.io/astral-sh/uv:python3.12-alpine
 
 # Install build dependencies for packages that need compilation (like psutil)
-RUN apk add --no-cache gcc python3-dev musl-dev linux-headers
+RUN apk add --no-cache gcc python3-dev musl-dev linux-headers curl
 
 # Install the project into `/app`
 WORKDIR /app


### PR DESCRIPTION
Follow up to #104 , we use curl for the health check but it's not installed in the backend container which was causing it to fail