### PR TITLE
perf: improve /leaderboard latency

### DIFF
--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -152,7 +152,7 @@ class NbaDataService:
                 status = NBAGameStatus.FINAL
 
         return {
-            "date_time": pd.to_datetime(game_timestamp, utc=True).astimezone(tz="US/Eastern"),
+            "date_time": pd.to_datetime(game_timestamp, format="ISO8601", utc=True).astimezone(tz="US/Eastern"),
             "game_id": game.get("gameId"),
             "home_team": game.get("homeTeam", {}).get("teamId"),
             "home_tricode": game.get("homeTeam", {}).get("teamTricode"),
@@ -227,7 +227,7 @@ class NbaDataService:
             if (
                 len(scoreboard_gameids) == 0
                 and scoreboard_date
-                and pd.to_datetime(game_date["gameDate"]).date() > scoreboard_date
+                and pd.to_datetime(game_date["gameDate"], format="ISO8601").date() > scoreboard_date
             ):
                 break
             for game in game_date["games"]:
@@ -255,11 +255,12 @@ class NbaDataService:
             DataFrame with game data including winning_team and losing_team columns
         """
         if season_year == self.get_current_season():
-            # combine CDN schedule and gamecardfeed
-            live_games, game_ids, scoreboard_date = self._parse_gamecardfeed(self._fetch_gamecardfeed_raw())
-            schedule = self._parse_schedule(
-                self._fetch_schedule_raw_cdn(), scoreboard_gameids=game_ids, scoreboard_date=scoreboard_date
+            raw_gamecardfeed, raw_schedule = await asyncio.gather(
+                asyncio.to_thread(self._fetch_gamecardfeed_raw),
+                asyncio.to_thread(self._fetch_schedule_raw_cdn),
             )
+            live_games, game_ids, scoreboard_date = self._parse_gamecardfeed(raw_gamecardfeed)
+            schedule = self._parse_schedule(raw_schedule, scoreboard_gameids=game_ids, scoreboard_date=scoreboard_date)
             schedule.extend(live_games)
             game_df = pd.DataFrame(schedule)
         else:

--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import logging
 import os
 from datetime import date
@@ -119,6 +120,18 @@ class NbaDataService:
         response.raise_for_status()
         return response.json()
 
+    @ttl_cache(ttl_seconds=10)
+    def _fetch_current_season_raw(self) -> tuple[dict, dict]:
+        """Fetch gamecardfeed and CDN schedule atomically in parallel.
+
+        Returns:
+            Tuple of (gamecardfeed_raw, schedule_raw)
+        """
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            f_gamecardfeed = executor.submit(self._fetch_gamecardfeed_raw)
+            f_schedule = executor.submit(self._fetch_schedule_raw_cdn)
+            return f_gamecardfeed.result(), f_schedule.result()
+
     @ttl_cache(ttl_seconds=86400)
     def get_current_season(self) -> str:
         """Fetch the current seasonYear string
@@ -126,7 +139,7 @@ class NbaDataService:
         Returns:
             string in format YYYY-YY
         """
-        schedule = self._fetch_schedule_raw_cdn()
+        _, schedule = self._fetch_current_season_raw()
         return schedule.get("leagueSchedule", {}).get("seasonYear")
 
     def _parse_game_data(self, game: dict, game_timestamp: str) -> dict:
@@ -152,7 +165,7 @@ class NbaDataService:
                 status = NBAGameStatus.FINAL
 
         return {
-            "date_time": pd.to_datetime(game_timestamp, format="ISO8601", utc=True).astimezone(tz="US/Eastern"),
+            "date_time": game_timestamp,
             "game_id": game.get("gameId"),
             "home_team": game.get("homeTeam", {}).get("teamId"),
             "home_tricode": game.get("homeTeam", {}).get("teamTricode"),
@@ -183,7 +196,7 @@ class NbaDataService:
                 if card.get("cardType") == "game" and card.get("cardData"):
                     if scoreboard_date is None:
                         scoreboard_date = (
-                            pd.to_datetime(card["cardData"].get("gameTimeUtc"), utc=True)
+                            pd.to_datetime(card["cardData"].get("gameTimeUtc"), format="ISO8601", utc=True)
                             .astimezone(tz="US/Eastern")
                             .date()
                         )
@@ -255,16 +268,17 @@ class NbaDataService:
             DataFrame with game data including winning_team and losing_team columns
         """
         if season_year == self.get_current_season():
-            raw_gamecardfeed, raw_schedule = await asyncio.gather(
-                asyncio.to_thread(self._fetch_gamecardfeed_raw),
-                asyncio.to_thread(self._fetch_schedule_raw_cdn),
-            )
+            raw_gamecardfeed, raw_schedule = await asyncio.to_thread(self._fetch_current_season_raw)
             live_games, game_ids, scoreboard_date = self._parse_gamecardfeed(raw_gamecardfeed)
             schedule = self._parse_schedule(raw_schedule, scoreboard_gameids=game_ids, scoreboard_date=scoreboard_date)
             schedule.extend(live_games)
             game_df = pd.DataFrame(schedule)
         else:
             game_df = pd.DataFrame(await self.get_historical_schedule_cached(season_year))
+
+        game_df["date_time"] = pd.to_datetime(game_df["date_time"], format="ISO8601", utc=True).dt.tz_convert(
+            "US/Eastern"
+        )
 
         game_df["winning_team"] = game_df["home_team"].where(
             (game_df.status == NBAGameStatus.FINAL) & (game_df.home_score > game_df.away_score),

--- a/backend/src/nba_wins_pool/utils/cache.py
+++ b/backend/src/nba_wins_pool/utils/cache.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from functools import wraps
 
@@ -5,26 +6,42 @@ from functools import wraps
 def ttl_cache(ttl_seconds):
     """
     A simple in-memory cache decorator with a time-to-live (TTL).
+    Supports both sync and async functions. Excludes `self` from the cache key
+    so the cache is shared across instances of the same class.
     """
     cache = {}
 
     def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            key = (args, frozenset(kwargs.items()))  # Create a hashable key
-            current_time = time.monotonic()
+        if asyncio.iscoroutinefunction(func):
 
-            if key in cache:
-                cached_value, expiration_time = cache[key]
-                if current_time < expiration_time:
-                    return cached_value
-                else:
-                    # Cache expired, remove it
+            @wraps(func)
+            async def wrapper(*args, **kwargs):
+                key = (args[1:], frozenset(kwargs.items()))
+                current_time = time.monotonic()
+                if key in cache:
+                    cached_value, expiration_time = cache[key]
+                    if current_time < expiration_time:
+                        return cached_value
                     del cache[key]
+                result = await func(*args, **kwargs)
+                cache[key] = (result, current_time + ttl_seconds)
+                return result
+        else:
 
-            # Cache miss or expired, call the original function
-            result = func(*args, **kwargs)
-            cache[key] = (result, current_time + ttl_seconds)
-            return result
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                key = (args[1:], frozenset(kwargs.items()))
+                current_time = time.monotonic()
+                if key in cache:
+                    cached_value, expiration_time = cache[key]
+                    if current_time < expiration_time:
+                        return cached_value
+                    del cache[key]
+                result = func(*args, **kwargs)
+                cache[key] = (result, current_time + ttl_seconds)
+                return result
+
+        wrapper.cache_clear = cache.clear
         return wrapper
+
     return decorator

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,12 +1,19 @@
+from unittest.mock import patch
+
 import pytest
 
 from nba_wins_pool.services.nba_data_service import NbaDataService
+
+_DEFAULT_CURRENT_SEASON_RAW = (
+    {"modules": []},
+    {"leagueSchedule": {"seasonYear": "2024-25", "gameDates": []}},
+)
 
 
 @pytest.fixture(autouse=True)
 def clear_nba_data_service_cache():
     NbaDataService.get_game_data.cache_clear()
     NbaDataService.get_current_season.cache_clear()
-    yield
-    NbaDataService.get_game_data.cache_clear()
-    NbaDataService.get_current_season.cache_clear()
+    NbaDataService._fetch_current_season_raw.cache_clear()
+    with patch.object(NbaDataService, "_fetch_current_season_raw", return_value=_DEFAULT_CURRENT_SEASON_RAW):
+        yield

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from nba_wins_pool.services.nba_data_service import NbaDataService
+
+
+@pytest.fixture(autouse=True)
+def clear_nba_data_service_cache():
+    NbaDataService.get_game_data.cache_clear()
+    NbaDataService.get_current_season.cache_clear()
+    yield
+    NbaDataService.get_game_data.cache_clear()
+    NbaDataService.get_current_season.cache_clear()

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -135,16 +135,15 @@ class TestGetGameData:
             }
         }
 
-        with patch.object(nba_service, "_fetch_gamecardfeed_raw", return_value=gamecardfeed_raw):
-            with patch.object(nba_service, "_fetch_schedule_raw_cdn", return_value=cdn_schedule_raw):
-                # Act
-                result = await nba_service.get_game_data(season)
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            # Act
+            result = await nba_service.get_game_data(season)
 
-                # Assert
-                assert isinstance(result, pd.DataFrame)
-                assert len(result) == 2  # Both live and schedule games
-                assert "winning_team" in result.columns
-                assert "losing_team" in result.columns
+            # Assert
+            assert isinstance(result, pd.DataFrame)
+            assert len(result) == 2  # Both live and schedule games
+            assert "winning_team" in result.columns
+            assert "losing_team" in result.columns
 
     @pytest.mark.asyncio
     async def test_get_game_data_historical_season_uses_cache(self, nba_service, mock_repo):


### PR DESCRIPTION
Identified 2 major bottlenecks in `/leaderboard`:
1. Calls to get schedule and gamecardfeed were happening sequentially. They now occur in parallel and are atomically cached (meaning cached together so they don't drift apart)
2. Improved parsing speed of schedule by vectorizing date parsing and providing the known date format

Overall when the ttl_cache is empty these changes lead to a speed up from ~1.4 seconds to ~400ms (71% faster)