### PR TITLE
feat: add tab to show today's games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ cython_debug/
 **/.DS_Store
 .prof
 .agent/
+CLAUDE.md

--- a/backend/src/nba_wins_pool/routes/pools.py
+++ b/backend/src/nba_wins_pool/routes/pools.py
@@ -45,19 +45,19 @@ async def get_pools(
 ):
     """Get all pools, optionally with their seasons in a single batch query"""
     pools = await pool_repo.get_all()
-    
+
     if include_seasons:
         # Batch query all seasons for all pools in a single database query
         pool_ids = [pool.id for pool in pools]
         all_seasons = await pool_season_repo.get_all_by_pools(pool_ids)
-        
+
         # Group seasons by pool_id
         seasons_by_pool = {}
         for season in all_seasons:
             if season.pool_id not in seasons_by_pool:
                 seasons_by_pool[season.pool_id] = []
             seasons_by_pool[season.pool_id].append(PoolListItemSeason(id=season.id, season=season.season))
-        
+
         # Build PoolListItem response models
         return [
             PoolListItem(
@@ -66,11 +66,11 @@ async def get_pools(
                 name=pool.name,
                 description=pool.description,
                 created_at=pool.created_at,
-                seasons=seasons_by_pool.get(pool.id, [])
+                seasons=seasons_by_pool.get(pool.id, []),
             )
             for pool in pools
         ]
-    
+
     return pools
 
 
@@ -130,6 +130,17 @@ async def leaderboard_v2(
 ):
     """Leaderboard"""
     data = await leaderboard_service.get_leaderboard(pool_id, season)
+    return JSONResponse(data)
+
+
+@router.get("/pools/{pool_id}/season/{season}/today-games", response_class=Response)
+async def today_games(
+    pool_id: UUID,
+    season: SeasonStr,
+    leaderboard_service: LeaderboardService = Depends(get_leaderboard_service),
+):
+    """Today's games with pool ownership info."""
+    data = await leaderboard_service.get_today_games(pool_id, season)
     return JSONResponse(data)
 
 

--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -318,6 +318,86 @@ class LeaderboardService:
 
         return results
 
+    async def get_today_games(self, pool_id: UUID, season: SeasonStr) -> list[dict]:
+        """Get today's games with pool ownership info.
+
+        Args:
+            pool_id: UUID of the pool
+            season: Season string in format YYYY-YY (e.g., "2024-25")
+
+        Returns:
+            List of game dicts with team, score, and owner info
+        """
+        game_df = await self.nba_data_service.get_game_data(season)
+
+        if game_df.empty:
+            return []
+
+        scoreboard_date = game_df["date_time"].max().date()
+        today_df = game_df[game_df["date_time"].dt.date == scoreboard_date].copy()
+
+        if today_df.empty:
+            return []
+
+        mappings = await self.pool_season_service.get_team_roster_mappings(
+            pool_id=pool_id,
+            season=season,
+            undrafted_name=UNDRAFTED_ROSTER_NAME,
+        )
+        teams_df = mappings.teams_df
+
+        def get_team_info(team_id):
+            if pd.isna(team_id):
+                return None
+            team_id = int(team_id)
+            return teams_df.loc[team_id] if team_id in teams_df.index else None
+
+        def safe_int(val):
+            return None if pd.isna(val) else int(val)
+
+        def safe_str(val):
+            return "" if pd.isna(val) else str(val)
+
+        status_sort = {NBAGameStatus.INGAME: 0, NBAGameStatus.PREGAME: 1, NBAGameStatus.FINAL: 2}
+
+        result = []
+        for _, game in today_df.iterrows():
+            home_info = get_team_info(game["home_team"])
+            away_info = get_team_info(game["away_team"])
+
+            result.append(
+                {
+                    "game_id": game["game_id"],
+                    "game_url": game["game_url"] if not pd.isna(game.get("game_url")) else None,
+                    "status": int(game["status"]),
+                    "status_text": safe_str(game["status_text"]),
+                    "game_clock": safe_str(game["game_clock"]),
+                    "home_team_id": safe_int(game["home_team"]),
+                    "home_team_name": home_info["team_name"]
+                    if home_info is not None
+                    else safe_str(game["home_tricode"]),
+                    "home_team_tricode": safe_str(game["home_tricode"]),
+                    "home_team_logo_url": home_info["logo_url"] if home_info is not None else None,
+                    "home_score": safe_int(game["home_score"]),
+                    "home_owner": home_info["roster_name"]
+                    if home_info is not None and home_info["roster_name"] != UNDRAFTED_ROSTER_NAME
+                    else None,
+                    "away_team_id": safe_int(game["away_team"]),
+                    "away_team_name": away_info["team_name"]
+                    if away_info is not None
+                    else safe_str(game["away_tricode"]),
+                    "away_team_tricode": safe_str(game["away_tricode"]),
+                    "away_team_logo_url": away_info["logo_url"] if away_info is not None else None,
+                    "away_score": safe_int(game["away_score"]),
+                    "away_owner": away_info["roster_name"]
+                    if away_info is not None and away_info["roster_name"] != UNDRAFTED_ROSTER_NAME
+                    else None,
+                }
+            )
+
+        result.sort(key=lambda g: (status_sort.get(g["status"], 99), g["game_id"] or ""))
+        return result
+
     def _compute_roster_standings(self, team_breakdown_df: pd.DataFrame) -> pd.DataFrame:
         """Compute roster-level standings from team breakdown.
 

--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -167,6 +167,7 @@ class NbaDataService:
         return {
             "date_time": game_timestamp,
             "game_id": game.get("gameId"),
+            "game_url": game.get("shareUrl"),
             "home_team": game.get("homeTeam", {}).get("teamId"),
             "home_tricode": game.get("homeTeam", {}).get("teamTricode"),
             "home_score": home_score,

--- a/backend/tests/fixtures/sample-nba-gamecardfeed-response.json
+++ b/backend/tests/fixtures/sample-nba-gamecardfeed-response.json
@@ -1,0 +1,3278 @@
+{
+    "nextPageToken": null,
+    "previousPageToken": null,
+    "headerConfiguration": {
+        "title": "Game Schedule",
+        "contents": [
+            "cast",
+            "profile"
+        ]
+    },
+    "stickyAdsConfiguration": {
+        "footerAds": [],
+        "headerAds": [],
+        "gamePlayerAds": []
+    },
+    "additionalSettings": {},
+    "modules": [
+        {
+            "moduleType": "list",
+            "moduleData": {
+                "placementId": "gameCardFeed_module0",
+                "layout": "padded",
+                "scrollBehavior": "page",
+                "header": null,
+                "footer": null,
+                "showPageIndicator": false,
+                "interItemSpacing": null
+            },
+            "cards": [
+                {
+                    "cardData": {
+                        "heroConfiguration": {
+                            "headline": "Nuggets @ Suns",
+                            "subhead": "",
+                            "image": {
+                                "imageUrl": "https://cdn.nba.com/manage/2026/03/den_vs_phx_game_recap_032426_thumbnail.png"
+                            },
+                            "video": null,
+                            "gameRecap": null,
+                            "headlineNoSpoilers": "Nuggets @ Suns"
+                        },
+                        "gameId": "0022501050",
+                        "leagueId": "00",
+                        "seasonYear": "2025-26",
+                        "seasonType": "Regular Season",
+                        "dailyGameRank": "1",
+                        "period": 2,
+                        "homeTeam": {
+                            "teamId": 1610612756,
+                            "teamName": "Suns",
+                            "wins": 40,
+                            "losses": 32,
+                            "teamSubtitle": "40-32",
+                            "score": 57,
+                            "timeoutsRemaining": 4,
+                            "inBonus": true,
+                            "teamTricode": "PHX",
+                            "teamSlug": "suns",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1626164",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 35
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 22
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 0
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1630224,
+                                "name": "Jalen Green",
+                                "jerseyNum": "4",
+                                "position": "SF",
+                                "teamTricode": "PHX",
+                                "playerSlug": "jalen-green",
+                                "points": "14",
+                                "rebounds": "4",
+                                "assists": "3",
+                                "blocks": "0",
+                                "steals": "0"
+                            }
+                        },
+                        "awayTeam": {
+                            "teamId": 1610612743,
+                            "teamName": "Nuggets",
+                            "wins": 44,
+                            "losses": 28,
+                            "teamSubtitle": "44-28",
+                            "score": 67,
+                            "timeoutsRemaining": 6,
+                            "inBonus": true,
+                            "teamTricode": "DEN",
+                            "teamSlug": "nuggets",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1627750",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 28
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 39
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 0
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 203999,
+                                "name": "Nikola Jokić",
+                                "jerseyNum": "15",
+                                "position": "C",
+                                "teamTricode": "DEN",
+                                "playerSlug": "nikola-jokić",
+                                "points": "15",
+                                "rebounds": "11",
+                                "assists": "9",
+                                "blocks": "0",
+                                "steals": "0"
+                            }
+                        },
+                        "seasonLeadersFlag": 0,
+                        "gameClock": "PT00M00.00S",
+                        "gameStatus": 2,
+                        "gameStatusText": "Half",
+                        "gameBreakStatus": "HALF",
+                        "gameState": 2,
+                        "duration": 0,
+                        "gameTimeEastern": "2026-03-24T23:00:00Z",
+                        "gameTimeUtc": "2026-03-25T03:00:00Z",
+                        "info": "",
+                        "subInfo": "",
+                        "gameDetailsHeader": {},
+                        "actions": [
+                            {
+                                "title": "Watch",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/den-vs-phx-0022501050?watch",
+                                    "resourceId": "0022501050",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Box Score",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/den-vs-phx-0022501050/box-score",
+                                    "resourceId": "0022501050",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Game Details",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/den-vs-phx-0022501050",
+                                    "resourceId": "0022501050",
+                                    "resourceType": "game"
+                                }
+                            }
+                        ],
+                        "images": {
+                            "1920x1080": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/den-phx/1920x1080.png",
+                            "1280x720": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/den-phx/1280x720.png",
+                            "640x360": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/den-phx/640x360.png",
+                            "480x270": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/den-phx/480x270.png",
+                            "320x180": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/den-phx/320x180.png",
+                            "160x90": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/den-phx/160x90.png"
+                        },
+                        "ifNecessary": false,
+                        "cardId": "",
+                        "contentAccess": {
+                            "isMemberGated": false,
+                            "isVivoContent": false,
+                            "cmsEntitlement": null,
+                            "isNikeGated": false
+                        },
+                        "shareUrl": "https://www.nba.com/game/den-vs-phx-0022501050",
+                        "ticketUrl": null,
+                        "isTntOT": false,
+                        "cardHat": null,
+                        "broadcasters": {
+                            "nationalBroadcasters": [
+                                {
+                                    "broadcasterId": 1001453,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "Peacock",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://peacocktv.app.link/gDLWIKw4p1b",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": "3",
+                                    "broadcasterLocalizationRegion": "",
+                                    "broadcasterLogoUrlDarkLg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/peacock.png",
+                                    "broadcasterLogoUrlLightLg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/peacock.png",
+                                    "broadcasterLogoUrlDarkSm": "https://cdn.nba.com/logos/nba/broadcast_logos/D/40h/peacock.png",
+                                    "broadcasterLogoUrlLightSm": "https://cdn.nba.com/logos/nba/broadcast_logos/L/40h/peacock.png",
+                                    "broadcasterLogoUrlLightSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/peacock.svg",
+                                    "broadcasterLogoUrlDarkSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/peacock.svg",
+                                    "broadcasterLogoIcon1x1": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/peacock.png",
+                                    "broadcasterLogoIcon1x1Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/peacock.svg",
+                                    "broadcasterLogoIcon16x9": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/peacock.png",
+                                    "broadcasterLogoIcon16x9Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/peacock.svg"
+                                },
+                                {
+                                    "broadcasterId": 1001452,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "NBC",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": "5",
+                                    "broadcasterLocalizationRegion": "West",
+                                    "broadcasterLogoUrlDarkLg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/nbc.png",
+                                    "broadcasterLogoUrlLightLg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/nbc.png",
+                                    "broadcasterLogoUrlDarkSm": "https://cdn.nba.com/logos/nba/broadcast_logos/D/40h/nbc.png",
+                                    "broadcasterLogoUrlLightSm": "https://cdn.nba.com/logos/nba/broadcast_logos/L/40h/nbc.png",
+                                    "broadcasterLogoUrlLightSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/nbc.svg",
+                                    "broadcasterLogoUrlDarkSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/nbc.svg",
+                                    "broadcasterLogoIcon1x1": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/nbc.png",
+                                    "broadcasterLogoIcon1x1Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/nbc.svg",
+                                    "broadcasterLogoIcon16x9": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/nbc.png",
+                                    "broadcasterLogoIcon16x9Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/nbc.svg"
+                                }
+                            ],
+                            "homeTvBroadcasters": [],
+                            "homeRadioBroadcasters": [],
+                            "awayTvBroadcasters": [],
+                            "awayRadioBroadcasters": [],
+                            "intlRadioBroadcasters": [],
+                            "intlTvBroadcasters": [],
+                            "homeOttBroadcasters": [],
+                            "awayOttBroadcasters": [],
+                            "intlOttBroadcasters": [],
+                            "nationalOttBroadcasters": [],
+                            "nationalRadioBroadcasters": [
+                                {
+                                    "broadcasterId": 1001098,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "SiriusXM",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://www.siriusxm.com/sports/nba",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": ""
+                                }
+                            ],
+                            "subscriptionBroadcasters": []
+                        },
+                        "showPostGameBroadcasters": false,
+                        "streamOrder": [
+                            {
+                                "rank": 0,
+                                "type": "production",
+                                "productionId": "g0022501050den1001457phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-NBC",
+                                "status": "Broadcast",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-nbc.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc.png"
+                                },
+                                "title": "NBC (In-Arena)",
+                                "description": "Follow in-arena action during halftime and game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-nbc.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-nbc.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 1,
+                                "type": "production",
+                                "productionId": "g0022501050den1001458phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-NBC-Studio",
+                                "status": "Broadcast",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-nbc-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc-studio.png"
+                                },
+                                "title": "NBC",
+                                "description": "Pre-game, halftime, and post game analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-nbc-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-nbc-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 2,
+                                "type": "production",
+                                "productionId": "g0022501050den1000455phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-DEN",
+                                "status": "Broadcast",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "DEN",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-den.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-den.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-den.png"
+                                },
+                                "title": "Nuggets (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612743,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-den.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-den.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 3,
+                                "type": "production",
+                                "productionId": "g0022501050den1000794phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-DEN-Studio",
+                                "status": "Verified",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-den-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-den-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-den-studio.png"
+                                },
+                                "title": "Nuggets (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-den-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-den-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 4,
+                                "type": "production",
+                                "productionId": "g0022501050den1001590phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Spanish-Mexico-Amazon",
+                                "status": "Broadcast",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-mexico-amazon.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-spanish-mexico-amazon.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-mexico-amazon.png"
+                                },
+                                "title": "Spanish (Prime Video)",
+                                "description": "Pre-game, halftime, and post game analysis",
+                                "categoryData": {
+                                    "categoryId": 44563,
+                                    "categoryName": "Languages",
+                                    "categoryRank": 4,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-spanish-mexico-amazon.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-spanish-mexico-amazon.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 5,
+                                "type": "production",
+                                "productionId": "g0022501050den1001591phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Portuguese-Brazil-Amazon",
+                                "status": "Broadcast",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-portuguese-brazil-amazon.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-portuguese-brazil-amazon.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-portuguese-brazil-amazon.png"
+                                },
+                                "title": "Portuguese (Prime Video)",
+                                "description": "Pre-game, halftime, and post game analysis",
+                                "categoryData": {
+                                    "categoryId": 44563,
+                                    "categoryName": "Languages",
+                                    "categoryRank": 4,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-portuguese-brazil-amazon.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-portuguese-brazil-amazon.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 6,
+                                "type": "production",
+                                "productionId": "g0022501050den1000444phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Mobile-View",
+                                "status": "Broadcast",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View (In-Arena)",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 7,
+                                "type": "production",
+                                "productionId": "g0022501050den1001513phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-DR-NBC",
+                                "status": "Started",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-nbc.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-dr-nbc.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-nbc.png"
+                                },
+                                "title": "NBC (In Arena)",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-dr-nbc.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-dr-nbc.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 8,
+                                "type": "production",
+                                "productionId": "g0022501050den1001365phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-DR-Team-DEN",
+                                "status": "Started",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-team-den.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-dr-team-den.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-team-den.png"
+                                },
+                                "title": "Nuggets (In Arena)",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-dr-team-den.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-dr-team-den.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 9,
+                                "type": "production",
+                                "productionId": "g0022501050den1000773phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-PHX",
+                                "status": "Broadcast",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-phx.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-phx.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-phx.png"
+                                },
+                                "title": "Suns Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-phx.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-phx.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 10,
+                                "type": "production",
+                                "productionId": "g0022501050den1000757phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-DEN",
+                                "status": "Broadcast",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-den.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-den.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-den.png"
+                                },
+                                "title": "Nuggets Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-den.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-den.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 11,
+                                "type": "production",
+                                "productionId": "g0022501050den1000846phx",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Spanish-Radio-Team-PHX",
+                                "status": "Broadcast",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-radio-team-phx.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-spanish-radio-team-phx.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-radio-team-phx.png"
+                                },
+                                "title": "Suns Radio - Spanish",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-spanish-radio-team-phx.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-spanish-radio-team-phx.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            }
+                        ],
+                        "extraMoreMenuItems": null,
+                        "gameSubtype": "",
+                        "isNeutral": false,
+                        "scoreStripHeader": {
+                            "scoreStripSpoilerHeader": "",
+                            "scoreStripNonSpoilerHeader": ""
+                        },
+                        "isTabletopGame": true,
+                        "actualStartTimeUTC": null,
+                        "actualEndTimeUTC": null,
+                        "gameDurationSeconds": null,
+                        "immersiveExperiences": null
+                    },
+                    "cardType": "game",
+                    "cardId": "25c9073b-49d7-3c06-9544-a4bc04c8661e"
+                },
+                {
+                    "cardData": {
+                        "heroConfiguration": {
+                            "headline": "Hornets win 4th straight",
+                            "subhead": "",
+                            "image": {
+                                "imageUrl": "https://cdn.nba.com/manage/2026/03/hornets-kings-meta-032426-scaled.jpg"
+                            },
+                            "video": null,
+                            "gameRecap": {
+                                "videoId": "2123710",
+                                "mediakindExternalProgramId": "a5ee98b124f3b09aae5bbfd9f62d52f0",
+                                "slug": "game-recap-hornets-134-kings-90",
+                                "title": "Game Recap: Hornets 134, Kings 90",
+                                "subTitle": "Charlotte wins their fourth straight, defeating the Kings, 134-90. Charlotte improves to 38-34, while the Kings fall to 19-54.",
+                                "shortTitle": null,
+                                "shareUrl": "https://www.nba.com/watch/video/game-recap-hornets-134-kings-90",
+                                "videoDuration": "2:18",
+                                "adMetaData": {
+                                    "cType": "nbaVod",
+                                    "caid": "nba-manage-prod-1-2123710",
+                                    "showPreviewAds": false,
+                                    "adfuelTarget": ""
+                                },
+                                "taxonomy": {
+                                    "categories": {
+                                        "game-recap": "Game Recap"
+                                    },
+                                    "tags": {
+                                        "charlotte-hornets": "charlotte hornets",
+                                        "coby-white": "Coby White",
+                                        "daeqwon-plowden": "Daeqwon Plowden",
+                                        "devin-carter": "devin carter",
+                                        "game-recap": "game recap",
+                                        "highlights": "highlights",
+                                        "lamelo-ball": "LaMelo Ball",
+                                        "recap": "recap",
+                                        "sacramento-kings": "sacramento kings"
+                                    },
+                                    "games": {
+                                        "0022501047": "SAC @ CHA (0022501047)"
+                                    },
+                                    "teams": {
+                                        "1610612758": "Sacramento Kings",
+                                        "1610612766": "Charlotte Hornets"
+                                    },
+                                    "players": {},
+                                    "videoFranchises": {
+                                        "game-recap": "Game Recap"
+                                    },
+                                    "videoFranchisesName": {
+                                        "2-min-game-recap": "2 Minute Game Recap"
+                                    },
+                                    "videoCategories": {
+                                        "recaps": "Recaps"
+                                    },
+                                    "videoTypes": {
+                                        "highlights": "Highlights"
+                                    },
+                                    "videoNumPlays": 0,
+                                    "videoPlayTypes": {},
+                                    "videoFrequency": {
+                                        "game": "Game"
+                                    },
+                                    "videoPublisher": {
+                                        "nbae": "NBAE"
+                                    }
+                                },
+                                "image": {
+                                    "imageUrl": "https://cdn.nba.com/manage/2026/03/SAC_CHA_RECAP_03242026.jpg"
+                                }
+                            },
+                            "headlineNoSpoilers": "Kings @ Hornets"
+                        },
+                        "gameId": "0022501047",
+                        "leagueId": "00",
+                        "seasonYear": "2025-26",
+                        "seasonType": "Regular Season",
+                        "dailyGameRank": "4",
+                        "period": 4,
+                        "homeTeam": {
+                            "teamId": 1610612766,
+                            "teamName": "Hornets",
+                            "wins": 38,
+                            "losses": 34,
+                            "teamSubtitle": "38-34",
+                            "score": 134,
+                            "timeoutsRemaining": 1,
+                            "inBonus": false,
+                            "teamTricode": "CHA",
+                            "teamSlug": "hornets",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1630163",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 34
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 38
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 41
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 21
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1630163,
+                                "name": "LaMelo Ball",
+                                "jerseyNum": "1",
+                                "position": "PG",
+                                "teamTricode": "CHA",
+                                "playerSlug": "lamelo-ball",
+                                "points": "20",
+                                "rebounds": "6",
+                                "assists": "8",
+                                "blocks": "0",
+                                "steals": "2"
+                            }
+                        },
+                        "awayTeam": {
+                            "teamId": 1610612758,
+                            "teamName": "Kings",
+                            "wins": 19,
+                            "losses": 54,
+                            "teamSubtitle": "19-54",
+                            "score": 90,
+                            "timeoutsRemaining": 1,
+                            "inBonus": false,
+                            "teamTricode": "SAC",
+                            "teamSlug": "kings",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1627734",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 25
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 22
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 29
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 14
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1631342,
+                                "name": "Daeqwon Plowden",
+                                "jerseyNum": "29",
+                                "position": "",
+                                "teamTricode": "SAC",
+                                "playerSlug": "daeqwon-plowden",
+                                "points": "22",
+                                "rebounds": "2",
+                                "assists": "1",
+                                "blocks": "0",
+                                "steals": "1"
+                            }
+                        },
+                        "seasonLeadersFlag": 0,
+                        "gameClock": "PT00M00.00S",
+                        "gameStatus": 3,
+                        "gameStatusText": "Final",
+                        "gameBreakStatus": "Final",
+                        "gameState": 3,
+                        "duration": 0,
+                        "gameTimeEastern": "2026-03-24T19:00:00Z",
+                        "gameTimeUtc": "2026-03-24T23:00:00Z",
+                        "info": "",
+                        "subInfo": "",
+                        "gameDetailsHeader": {},
+                        "actions": [
+                            {
+                                "title": "Watch",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/sac-vs-cha-0022501047?watch",
+                                    "resourceId": "0022501047",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Box Score",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/sac-vs-cha-0022501047/box-score",
+                                    "resourceId": "0022501047",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Game Details",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/sac-vs-cha-0022501047",
+                                    "resourceId": "0022501047",
+                                    "resourceType": "game"
+                                }
+                            }
+                        ],
+                        "images": {
+                            "1920x1080": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/sac-cha/1920x1080.png",
+                            "1280x720": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/sac-cha/1280x720.png",
+                            "640x360": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/sac-cha/640x360.png",
+                            "480x270": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/sac-cha/480x270.png",
+                            "320x180": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/sac-cha/320x180.png",
+                            "160x90": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/sac-cha/160x90.png"
+                        },
+                        "ifNecessary": false,
+                        "cardId": "",
+                        "contentAccess": {
+                            "isMemberGated": false,
+                            "isVivoContent": false,
+                            "cmsEntitlement": null,
+                            "isNikeGated": false
+                        },
+                        "shareUrl": "https://www.nba.com/game/sac-vs-cha-0022501047",
+                        "ticketUrl": null,
+                        "isTntOT": false,
+                        "cardHat": null,
+                        "broadcasters": {
+                            "nationalBroadcasters": [],
+                            "homeTvBroadcasters": [],
+                            "homeRadioBroadcasters": [],
+                            "awayTvBroadcasters": [],
+                            "awayRadioBroadcasters": [],
+                            "intlRadioBroadcasters": [],
+                            "intlTvBroadcasters": [],
+                            "homeOttBroadcasters": [],
+                            "awayOttBroadcasters": [],
+                            "intlOttBroadcasters": [],
+                            "nationalOttBroadcasters": [],
+                            "nationalRadioBroadcasters": [
+                                {
+                                    "broadcasterId": 1001098,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "SiriusXM",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://www.siriusxm.com/sports/nba",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": ""
+                                }
+                            ],
+                            "subscriptionBroadcasters": [
+                                {
+                                    "broadcasterId": 0,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "League Pass",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": null,
+                                    "broadcasterDescription": null,
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": null,
+                                    "broadcasterLogoIcon1x1": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/league-pass.png",
+                                    "broadcasterLogoIcon1x1Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/league-pass.svg",
+                                    "broadcasterLogoIcon16x9": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/league-pass.png",
+                                    "broadcasterLogoIcon16x9Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/league-pass.svg"
+                                }
+                            ]
+                        },
+                        "showPostGameBroadcasters": true,
+                        "streamOrder": [
+                            {
+                                "rank": 0,
+                                "type": "production",
+                                "productionId": "g0022501047sac1000451cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-CHA",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "CHA",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-cha.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-cha.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-cha.png"
+                                },
+                                "title": "Hornets (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612766,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-cha.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-cha.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 1,
+                                "type": "production",
+                                "productionId": "g0022501047sac1000473cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-SAC",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "SAC",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-sac.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-sac.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-sac.png"
+                                },
+                                "title": "Kings (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612758,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-sac.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-sac.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 2,
+                                "type": "production",
+                                "productionId": "g0022501047sac1000790cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-CHA-Studio",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-cha-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-cha-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-cha-studio.png"
+                                },
+                                "title": "Hornets (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-cha-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-cha-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 3,
+                                "type": "production",
+                                "productionId": "g0022501047sac1000812cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-SAC-Studio",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-sac-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-sac-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-sac-studio.png"
+                                },
+                                "title": "Kings (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-sac-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-sac-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 4,
+                                "type": "production",
+                                "productionId": "g0022501047sac1001255cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-AI-Generated-French",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-french.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-ai-generated-french.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-french.png"
+                                },
+                                "title": "French - AI Generated",
+                                "description": "AI Generated French language stream - Beta Version",
+                                "categoryData": {
+                                    "categoryId": 44563,
+                                    "categoryName": "Languages",
+                                    "categoryRank": 4,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-ai-generated-french.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-ai-generated-french.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 5,
+                                "type": "production",
+                                "productionId": "g0022501047sac1001252cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-AI-Generated-Spanish",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-spanish.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-ai-generated-spanish.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-spanish.png"
+                                },
+                                "title": "Spanish - AI Generated",
+                                "description": "AI Generated Spanish language stream - Beta Version",
+                                "categoryData": {
+                                    "categoryId": 44563,
+                                    "categoryName": "Languages",
+                                    "categoryRank": 4,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-ai-generated-spanish.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-ai-generated-spanish.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 6,
+                                "type": "production",
+                                "productionId": "g0022501047sac1001253cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-AI-Generated-Portuguese",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-portuguese.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-ai-generated-portuguese.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-portuguese.png"
+                                },
+                                "title": "Portuguese - AI Generated",
+                                "description": "AI Generated Portuguese language stream - Beta Version",
+                                "categoryData": {
+                                    "categoryId": 44563,
+                                    "categoryName": "Languages",
+                                    "categoryRank": 4,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-ai-generated-portuguese.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-ai-generated-portuguese.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 7,
+                                "type": "production",
+                                "productionId": "g0022501047sac1000444cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Mobile-View",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View (In-Arena)",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 8,
+                                "type": "production",
+                                "productionId": "g0022501047sac1000753cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-CHA",
+                                "status": "Over",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-cha.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-cha.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-cha.png"
+                                },
+                                "title": "Hornets Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-cha.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-cha.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 9,
+                                "type": "production",
+                                "productionId": "g0022501047sac1000775cha",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-SAC",
+                                "status": "Over",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-sac.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-sac.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-sac.png"
+                                },
+                                "title": "Kings Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-sac.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-sac.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 4,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501047sac1001255chaV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-ai-generated-french.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-french.png"
+                                },
+                                "title": "French (AI Generated)",
+                                "description": "AI Generated French language stream - Beta Version",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-ai-generated-french.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-ai-generated-french.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 6,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501047sac1001253chaV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-ai-generated-portuguese.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-portuguese.png"
+                                },
+                                "title": "Portuguese (AI-Generated)",
+                                "description": "AI Generated Portuguese language stream - Beta Version",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-ai-generated-portuguese.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-ai-generated-portuguese.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "portuguese-broadcast"
+                            },
+                            {
+                                "rank": 1,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501047sac1000473chaV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-sac.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-sac.png"
+                                },
+                                "title": "Kings",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-sac.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-sac.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "local-away-broadcast"
+                            },
+                            {
+                                "rank": 0,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501047sac1000451chaV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-cha.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-cha.png"
+                                },
+                                "title": "Hornets",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-cha.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-cha.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "local-home-broadcast"
+                            },
+                            {
+                                "rank": 5,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501047sac1001252chaV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-ai-generated-spanish.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-ai-generated-spanish.png"
+                                },
+                                "title": "Spanish (AI-Generated)",
+                                "description": "AI Generated Spanish language stream - Beta Version",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-ai-generated-spanish.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-ai-generated-spanish.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "spanish-broadcast"
+                            },
+                            {
+                                "rank": 7,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501047sac1000444chaV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "mobile-broadcast"
+                            },
+                            {
+                                "rank": 6,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_489B942528CF88B89C3A9B0E70AE20C14D4F0C2C",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/sac-condensed.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/sac-condensed.png"
+                                },
+                                "title": "Kings Condensed",
+                                "description": "Extended away team highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/sac-condensed.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/sac-condensed.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "4:58",
+                                "videoFranchisesName": "away-best-plays"
+                            },
+                            {
+                                "rank": 5,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_11B2A95A1C968428313218D47F6B3EAECD75D339",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/cha-condensed.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/cha-condensed.png"
+                                },
+                                "title": "Hornets Condensed",
+                                "description": "Extended home team highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/cha-condensed.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/cha-condensed.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "4:56",
+                                "videoFranchisesName": "home-best-plays"
+                            },
+                            {
+                                "rank": 4,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_36D330C34EADF1F72A60811E436586C46C3AC7D1",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/all-possessions.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/all-possessions.png"
+                                },
+                                "title": "All Possessions",
+                                "description": "All plays without game breaks or commercials",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/all-possessions.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/all-possessions.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "36:13",
+                                "videoFranchisesName": "all-possessions-cg"
+                            },
+                            {
+                                "rank": 1,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_202603242227NBA_____VIDEOS__NBAE_2911446",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/game-recap.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/game-recap.png"
+                                },
+                                "title": "Game Recap",
+                                "description": "Highlights with commentary",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/manage/2026/03/SAC_CHA_RECAP_03242026.jpg",
+                                    "thumbnailSmall": "https://cdn.nba.com/manage/2026/03/SAC_CHA_RECAP_03242026.jpg"
+                                },
+                                "featuredImage": "https://cdn.nba.com/manage/2026/03/SAC_CHA_RECAP_03242026.jpg",
+                                "videoDuration": "2:18",
+                                "videoFranchisesName": "2-min-game-recap"
+                            },
+                            {
+                                "rank": 3,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_51BD8D4EE8FE8471B7D4A129CEEC56B199AE7033",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/10-minute.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/10-minute.png"
+                                },
+                                "title": "Condensed Game",
+                                "description": "Extended game highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/10-minute.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/10-minute.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "17:32",
+                                "videoFranchisesName": "full-game-highlights"
+                            },
+                            {
+                                "rank": 2,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_0AF8CAF291EB2FAFC8067AE85CA36A6DAEB85818",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/key-highlights.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/key-highlights.png"
+                                },
+                                "title": "Key Highlights",
+                                "description": "Key plays with broadcast audio",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/key-highlights.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/key-highlights.png"
+                                },
+                                "featuredImage": "https://cdn.nba.com/manage/2026/03/306d88a7-c103-4374-a97a-0943547535cf_0.jpg",
+                                "videoDuration": "1:58",
+                                "videoFranchisesName": "wsc-key-highlights"
+                            }
+                        ],
+                        "extraMoreMenuItems": null,
+                        "gameSubtype": "",
+                        "isNeutral": false,
+                        "scoreStripHeader": {
+                            "scoreStripSpoilerHeader": "",
+                            "scoreStripNonSpoilerHeader": ""
+                        },
+                        "isTabletopGame": true,
+                        "actualStartTimeUTC": "2026-03-24T23:10:49Z",
+                        "actualEndTimeUTC": "2026-03-25T01:13:00Z",
+                        "gameDurationSeconds": 7331,
+                        "immersiveExperiences": null
+                    },
+                    "cardType": "game",
+                    "cardId": "d3d2a546-275b-3eb3-24d4-b8c5e850c645"
+                },
+                {
+                    "cardData": {
+                        "heroConfiguration": {
+                            "headline": "7 wins in row for Knicks",
+                            "subhead": "",
+                            "image": {
+                                "imageUrl": "https://cdn.nba.com/manage/2026/03/brunson-pels-meta-032426-scaled.jpg"
+                            },
+                            "video": null,
+                            "gameRecap": {
+                                "videoId": "2123848",
+                                "mediakindExternalProgramId": "d77e7ff0213f78b35a2ce70b47b5d8dc",
+                                "slug": "game-recap-knicks-121-pelicans-116",
+                                "title": "Game Recap: Knicks 121, Pelicans 116",
+                                "subTitle": "The Knicks won their seventh straight game by defeating the Pelicans, 121-116. ",
+                                "shortTitle": null,
+                                "shareUrl": "https://www.nba.com/watch/video/game-recap-knicks-121-pelicans-116",
+                                "videoDuration": "2:27",
+                                "adMetaData": {
+                                    "cType": "nbaVod",
+                                    "caid": "nba-manage-prod-1-2123848",
+                                    "showPreviewAds": false,
+                                    "adfuelTarget": ""
+                                },
+                                "taxonomy": {
+                                    "categories": {
+                                        "game-recap": "Game Recap"
+                                    },
+                                    "tags": {
+                                        "game-recap": "game recap",
+                                        "highlights": "highlights",
+                                        "jalen-brunson": "Jalen Brunson",
+                                        "jeremiah-fears": "Jeremiah Fears",
+                                        "new-orleans-pelicans": "New Orleans Pelicans",
+                                        "new-york-knicks": "New York Knicks",
+                                        "og-anunoby": "OG Anunoby",
+                                        "recap": "recap",
+                                        "zion-williamson": "Zion Williamson"
+                                    },
+                                    "games": {
+                                        "0022501048": "NOP @ NYK (0022501048)"
+                                    },
+                                    "teams": {
+                                        "1610612740": "New Orleans Pelicans",
+                                        "1610612752": "New York Knicks"
+                                    },
+                                    "players": {},
+                                    "videoFranchises": {
+                                        "game-recap": "Game Recap"
+                                    },
+                                    "videoFranchisesName": {
+                                        "2-min-game-recap": "2 Minute Game Recap"
+                                    },
+                                    "videoCategories": {
+                                        "recaps": "Recaps"
+                                    },
+                                    "videoTypes": {
+                                        "highlights": "Highlights"
+                                    },
+                                    "videoNumPlays": 0,
+                                    "videoPlayTypes": {},
+                                    "videoFrequency": {
+                                        "game": "Game"
+                                    },
+                                    "videoPublisher": {
+                                        "nbae": "NBAE"
+                                    }
+                                },
+                                "image": {
+                                    "imageUrl": "https://cdn.nba.com/manage/2026/03/NOP_NYK_RECAP_BRUNSONVERSION_03242026.jpg"
+                                }
+                            },
+                            "headlineNoSpoilers": "Pelicans @ Knicks"
+                        },
+                        "gameId": "0022501048",
+                        "leagueId": "00",
+                        "seasonYear": "2025-26",
+                        "seasonType": "Regular Season",
+                        "dailyGameRank": "3",
+                        "period": 4,
+                        "homeTeam": {
+                            "teamId": 1610612752,
+                            "teamName": "Knicks",
+                            "wins": 48,
+                            "losses": 25,
+                            "teamSubtitle": "48-25",
+                            "score": 121,
+                            "timeoutsRemaining": 0,
+                            "inBonus": false,
+                            "teamTricode": "NYK",
+                            "teamSlug": "knicks",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1628973",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 42
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 24
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 27
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 28
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1628973,
+                                "name": "Jalen Brunson",
+                                "jerseyNum": "11",
+                                "position": "PG",
+                                "teamTricode": "NYK",
+                                "playerSlug": "jalen-brunson",
+                                "points": "32",
+                                "rebounds": "1",
+                                "assists": "7",
+                                "blocks": "0",
+                                "steals": "0"
+                            }
+                        },
+                        "awayTeam": {
+                            "teamId": 1610612740,
+                            "teamName": "Pelicans",
+                            "wins": 25,
+                            "losses": 48,
+                            "teamSubtitle": "25-48",
+                            "score": 116,
+                            "timeoutsRemaining": 0,
+                            "inBonus": false,
+                            "teamTricode": "NOP",
+                            "teamSlug": "pelicans",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1629627",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 28
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 32
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 32
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 24
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1629627,
+                                "name": "Zion Williamson",
+                                "jerseyNum": "1",
+                                "position": "PF",
+                                "teamTricode": "NOP",
+                                "playerSlug": "zion-williamson",
+                                "points": "22",
+                                "rebounds": "4",
+                                "assists": "2",
+                                "blocks": "1",
+                                "steals": "1"
+                            }
+                        },
+                        "seasonLeadersFlag": 0,
+                        "gameClock": "PT00M00.00S",
+                        "gameStatus": 3,
+                        "gameStatusText": "Final",
+                        "gameBreakStatus": "Final",
+                        "gameState": 3,
+                        "duration": 0,
+                        "gameTimeEastern": "2026-03-24T19:30:00Z",
+                        "gameTimeUtc": "2026-03-24T23:30:00Z",
+                        "info": "",
+                        "subInfo": "",
+                        "gameDetailsHeader": {},
+                        "actions": [
+                            {
+                                "title": "Watch",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/nop-vs-nyk-0022501048?watch",
+                                    "resourceId": "0022501048",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Box Score",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/nop-vs-nyk-0022501048/box-score",
+                                    "resourceId": "0022501048",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Game Details",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/nop-vs-nyk-0022501048",
+                                    "resourceId": "0022501048",
+                                    "resourceType": "game"
+                                }
+                            }
+                        ],
+                        "images": {
+                            "1920x1080": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/nop-nyk/1920x1080.png",
+                            "1280x720": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/nop-nyk/1280x720.png",
+                            "640x360": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/nop-nyk/640x360.png",
+                            "480x270": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/nop-nyk/480x270.png",
+                            "320x180": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/nop-nyk/320x180.png",
+                            "160x90": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/nop-nyk/160x90.png"
+                        },
+                        "ifNecessary": false,
+                        "cardId": "",
+                        "contentAccess": {
+                            "isMemberGated": false,
+                            "isVivoContent": false,
+                            "cmsEntitlement": null,
+                            "isNikeGated": false
+                        },
+                        "shareUrl": "https://www.nba.com/game/nop-vs-nyk-0022501048",
+                        "ticketUrl": null,
+                        "isTntOT": false,
+                        "cardHat": null,
+                        "broadcasters": {
+                            "nationalBroadcasters": [],
+                            "homeTvBroadcasters": [],
+                            "homeRadioBroadcasters": [],
+                            "awayTvBroadcasters": [],
+                            "awayRadioBroadcasters": [],
+                            "intlRadioBroadcasters": [],
+                            "intlTvBroadcasters": [],
+                            "homeOttBroadcasters": [],
+                            "awayOttBroadcasters": [],
+                            "intlOttBroadcasters": [],
+                            "nationalOttBroadcasters": [],
+                            "nationalRadioBroadcasters": [
+                                {
+                                    "broadcasterId": 1001098,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "SiriusXM",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://www.siriusxm.com/sports/nba",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": ""
+                                }
+                            ],
+                            "subscriptionBroadcasters": [
+                                {
+                                    "broadcasterId": 0,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "League Pass",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": null,
+                                    "broadcasterDescription": null,
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": null,
+                                    "broadcasterLogoIcon1x1": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/league-pass.png",
+                                    "broadcasterLogoIcon1x1Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/league-pass.svg",
+                                    "broadcasterLogoIcon16x9": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/league-pass.png",
+                                    "broadcasterLogoIcon16x9Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/league-pass.svg"
+                                }
+                            ]
+                        },
+                        "showPostGameBroadcasters": true,
+                        "streamOrder": [
+                            {
+                                "rank": 0,
+                                "type": "production",
+                                "productionId": "g0022501048nop1000467nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-NYK",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "NYK",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-nyk.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-nyk.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-nyk.png"
+                                },
+                                "title": "Knicks (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612752,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-nyk.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-nyk.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 1,
+                                "type": "production",
+                                "productionId": "g0022501048nop1000466nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-NOP",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "NOP",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-nop.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-nop.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-nop.png"
+                                },
+                                "title": "Pelicans (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612740,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-nop.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-nop.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 2,
+                                "type": "production",
+                                "productionId": "g0022501048nop1000806nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-NYK-Studio",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-nyk-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-nyk-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-nyk-studio.png"
+                                },
+                                "title": "Knicks (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-nyk-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-nyk-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 3,
+                                "type": "production",
+                                "productionId": "g0022501048nop1000805nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-NOP-Studio",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-nop-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-nop-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-nop-studio.png"
+                                },
+                                "title": "Pelicans (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-nop-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-nop-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 4,
+                                "type": "production",
+                                "productionId": "g0022501048nop1001069nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-Local-NOP",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "NOP",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-local-nop.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-local-nop.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-local-nop.png"
+                                },
+                                "title": "Pelicans+",
+                                "description": "Local live game broadcast",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": true,
+                                "teamId": 1610612740,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-local-nop.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-local-nop.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 5,
+                                "type": "production",
+                                "productionId": "g0022501048nop1000444nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Mobile-View",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View (In-Arena)",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 6,
+                                "type": "production",
+                                "productionId": "g0022501048nop1001376nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-DR-Team-NYK",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-team-nyk.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-dr-team-nyk.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-team-nyk.png"
+                                },
+                                "title": "Knicks (In Arena)",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-dr-team-nyk.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-dr-team-nyk.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 7,
+                                "type": "production",
+                                "productionId": "g0022501048nop1000768nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-NOP",
+                                "status": "Over",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-nop.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-nop.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-nop.png"
+                                },
+                                "title": "Pelicans Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-nop.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-nop.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 8,
+                                "type": "production",
+                                "productionId": "g0022501048nop1000769nyk",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-NYK",
+                                "status": "Over",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-nyk.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-nyk.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-nyk.png"
+                                },
+                                "title": "Knicks Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-nyk.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-nyk.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 0,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501048nop1000467nykV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-nyk.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-nyk.png"
+                                },
+                                "title": "Knicks",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-nyk.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-nyk.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "local-home-broadcast"
+                            },
+                            {
+                                "rank": 5,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501048nop1000444nykV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "mobile-broadcast"
+                            },
+                            {
+                                "rank": 1,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501048nop1000466nykV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-nop.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-nop.png"
+                                },
+                                "title": "Pelicans",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-nop.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-nop.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "local-away-broadcast"
+                            },
+                            {
+                                "rank": 3,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_2ACE1D5A04840747DC93AE036AF446B37E6ADA09",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/10-minute.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/10-minute.png"
+                                },
+                                "title": "Condensed Game",
+                                "description": "Extended game highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/10-minute.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/10-minute.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "17:36",
+                                "videoFranchisesName": "full-game-highlights"
+                            },
+                            {
+                                "rank": 4,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_4EFDBA6F9BD53042BDBAC8499321852DBC0A4530",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/all-possessions.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/all-possessions.png"
+                                },
+                                "title": "All Possessions",
+                                "description": "All plays without game breaks or commercials",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/all-possessions.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/all-possessions.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "38:23",
+                                "videoFranchisesName": "all-possessions-cg"
+                            },
+                            {
+                                "rank": 1,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_202603242301NBA_____VIDEOS__NBAE_2911465",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/game-recap.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/game-recap.png"
+                                },
+                                "title": "Game Recap",
+                                "description": "Highlights with commentary",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/manage/2026/03/NOP_NYK_RECAP_BRUNSONVERSION_03242026.jpg",
+                                    "thumbnailSmall": "https://cdn.nba.com/manage/2026/03/NOP_NYK_RECAP_BRUNSONVERSION_03242026.jpg"
+                                },
+                                "featuredImage": "https://cdn.nba.com/manage/2026/03/NOP_NYK_RECAP_BRUNSONVERSION_03242026.jpg",
+                                "videoDuration": "2:27",
+                                "videoFranchisesName": "2-min-game-recap"
+                            },
+                            {
+                                "rank": 6,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_253B02F0377FC6CAE0A63D794E4B5C72126916D8",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nop-condensed.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nop-condensed.png"
+                                },
+                                "title": "Pelicans Condensed",
+                                "description": "Extended away team highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nop-condensed.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nop-condensed.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "4:57",
+                                "videoFranchisesName": "away-best-plays"
+                            },
+                            {
+                                "rank": 5,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_158BBA4CD11257D0BB80BDCDF615ED23CE530D73",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nyk-condensed.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nyk-condensed.png"
+                                },
+                                "title": "Knicks Condensed",
+                                "description": "Extended home team highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nyk-condensed.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nyk-condensed.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "5:00",
+                                "videoFranchisesName": "home-best-plays"
+                            },
+                            {
+                                "rank": 2,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_8639D07331F2D46132070F1B31481DD91DA04664",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/key-highlights.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/key-highlights.png"
+                                },
+                                "title": "Key Highlights",
+                                "description": "Key plays with broadcast audio",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/key-highlights.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/key-highlights.png"
+                                },
+                                "featuredImage": "https://cdn.nba.com/manage/2026/03/2eb65f4f-8ef0-4eae-a470-d99700302e57_0.jpg",
+                                "videoDuration": "2:01",
+                                "videoFranchisesName": "wsc-key-highlights"
+                            }
+                        ],
+                        "extraMoreMenuItems": null,
+                        "gameSubtype": "",
+                        "isNeutral": false,
+                        "scoreStripHeader": {
+                            "scoreStripSpoilerHeader": "",
+                            "scoreStripNonSpoilerHeader": ""
+                        },
+                        "isTabletopGame": true,
+                        "actualStartTimeUTC": "2026-03-24T23:43:18Z",
+                        "actualEndTimeUTC": "2026-03-25T01:59:36Z",
+                        "gameDurationSeconds": 8178,
+                        "immersiveExperiences": null
+                    },
+                    "cardType": "game",
+                    "cardId": "b1dda896-98bc-fb3e-4c57-2f78d10afa21"
+                },
+                {
+                    "cardData": {
+                        "heroConfiguration": {
+                            "headline": "Mitchell dazzles with 42",
+                            "subhead": "",
+                            "image": {
+                                "imageUrl": "https://cdn.nba.com/manage/2026/03/mitchell-magic-meta-032426.jpg"
+                            },
+                            "video": null,
+                            "gameRecap": null,
+                            "headlineNoSpoilers": "Magic @ Cavaliers"
+                        },
+                        "gameId": "0022501049",
+                        "leagueId": "00",
+                        "seasonYear": "2025-26",
+                        "seasonType": "Regular Season",
+                        "dailyGameRank": "2",
+                        "period": 4,
+                        "homeTeam": {
+                            "teamId": 1610612739,
+                            "teamName": "Cavaliers",
+                            "wins": 45,
+                            "losses": 27,
+                            "teamSubtitle": "45-27",
+                            "score": 136,
+                            "timeoutsRemaining": 0,
+                            "inBonus": false,
+                            "teamTricode": "CLE",
+                            "teamSlug": "cavaliers",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1628378",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 32
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 40
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 33
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 31
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1628378,
+                                "name": "Donovan Mitchell",
+                                "jerseyNum": "45",
+                                "position": "SG",
+                                "teamTricode": "CLE",
+                                "playerSlug": "donovan-mitchell",
+                                "points": "42",
+                                "rebounds": "2",
+                                "assists": "3",
+                                "blocks": "0",
+                                "steals": "0"
+                            }
+                        },
+                        "awayTeam": {
+                            "teamId": 1610612753,
+                            "teamName": "Magic",
+                            "wins": 38,
+                            "losses": 34,
+                            "teamSubtitle": "38-34",
+                            "score": 131,
+                            "timeoutsRemaining": 0,
+                            "inBonus": false,
+                            "teamTricode": "ORL",
+                            "teamSlug": "magic",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1631094",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 39
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 29
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 29
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 34
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1631094,
+                                "name": "Paolo Banchero",
+                                "jerseyNum": "5",
+                                "position": "PF",
+                                "teamTricode": "ORL",
+                                "playerSlug": "paolo-banchero",
+                                "points": "36",
+                                "rebounds": "6",
+                                "assists": "5",
+                                "blocks": "1",
+                                "steals": "1"
+                            }
+                        },
+                        "seasonLeadersFlag": 0,
+                        "gameClock": "PT00M00.00S",
+                        "gameStatus": 3,
+                        "gameStatusText": "Final",
+                        "gameBreakStatus": "Final",
+                        "gameState": 3,
+                        "duration": 0,
+                        "gameTimeEastern": "2026-03-24T20:00:00Z",
+                        "gameTimeUtc": "2026-03-25T00:00:00Z",
+                        "info": "",
+                        "subInfo": "",
+                        "gameDetailsHeader": {},
+                        "actions": [
+                            {
+                                "title": "Watch",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/orl-vs-cle-0022501049?watch",
+                                    "resourceId": "0022501049",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Box Score",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/orl-vs-cle-0022501049/box-score",
+                                    "resourceId": "0022501049",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Game Details",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/orl-vs-cle-0022501049",
+                                    "resourceId": "0022501049",
+                                    "resourceType": "game"
+                                }
+                            }
+                        ],
+                        "images": {
+                            "1920x1080": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/orl-cle/1920x1080.png",
+                            "1280x720": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/orl-cle/1280x720.png",
+                            "640x360": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/orl-cle/640x360.png",
+                            "480x270": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/orl-cle/480x270.png",
+                            "320x180": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/orl-cle/320x180.png",
+                            "160x90": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/orl-cle/160x90.png"
+                        },
+                        "ifNecessary": false,
+                        "cardId": "",
+                        "contentAccess": {
+                            "isMemberGated": false,
+                            "isVivoContent": false,
+                            "cmsEntitlement": null,
+                            "isNikeGated": false
+                        },
+                        "shareUrl": "https://www.nba.com/game/orl-vs-cle-0022501049",
+                        "ticketUrl": null,
+                        "isTntOT": false,
+                        "cardHat": null,
+                        "broadcasters": {
+                            "nationalBroadcasters": [
+                                {
+                                    "broadcasterId": 1001453,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "Peacock",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://peacocktv.app.link/7CxDIzv4p1b",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": "3",
+                                    "broadcasterLocalizationRegion": "",
+                                    "broadcasterLogoUrlDarkLg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/peacock.png",
+                                    "broadcasterLogoUrlLightLg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/peacock.png",
+                                    "broadcasterLogoUrlDarkSm": "https://cdn.nba.com/logos/nba/broadcast_logos/D/40h/peacock.png",
+                                    "broadcasterLogoUrlLightSm": "https://cdn.nba.com/logos/nba/broadcast_logos/L/40h/peacock.png",
+                                    "broadcasterLogoUrlLightSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/peacock.svg",
+                                    "broadcasterLogoUrlDarkSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/peacock.svg",
+                                    "broadcasterLogoIcon1x1": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/peacock.png",
+                                    "broadcasterLogoIcon1x1Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/peacock.svg",
+                                    "broadcasterLogoIcon16x9": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/peacock.png",
+                                    "broadcasterLogoIcon16x9Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/peacock.svg"
+                                }
+                            ],
+                            "homeTvBroadcasters": [],
+                            "homeRadioBroadcasters": [],
+                            "awayTvBroadcasters": [],
+                            "awayRadioBroadcasters": [],
+                            "intlRadioBroadcasters": [],
+                            "intlTvBroadcasters": [],
+                            "homeOttBroadcasters": [],
+                            "awayOttBroadcasters": [],
+                            "intlOttBroadcasters": [],
+                            "nationalOttBroadcasters": [],
+                            "nationalRadioBroadcasters": [
+                                {
+                                    "broadcasterId": 1001098,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "SiriusXM",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://www.siriusxm.com/sports/nba",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": ""
+                                }
+                            ],
+                            "subscriptionBroadcasters": []
+                        },
+                        "showPostGameBroadcasters": false,
+                        "streamOrder": [
+                            {
+                                "rank": 0,
+                                "type": "production",
+                                "productionId": "g0022501049orl1001457cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-NBC",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-nbc.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc.png"
+                                },
+                                "title": "NBC (In-Arena)",
+                                "description": "Follow in-arena action during halftime and game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-nbc.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-nbc.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 1,
+                                "type": "production",
+                                "productionId": "g0022501049orl1001458cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-NBC-Studio",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-nbc-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc-studio.png"
+                                },
+                                "title": "NBC",
+                                "description": "Pre-game, halftime, and post game analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-nbc-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-nbc-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 2,
+                                "type": "production",
+                                "productionId": "g0022501049orl1000453cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-CLE",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "CLE",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-cle.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-cle.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-cle.png"
+                                },
+                                "title": "Cavaliers (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612739,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-cle.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-cle.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 3,
+                                "type": "production",
+                                "productionId": "g0022501049orl1000792cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-CLE-Studio",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-cle-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-cle-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-cle-studio.png"
+                                },
+                                "title": "Cavaliers (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-cle-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-cle-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 4,
+                                "type": "production",
+                                "productionId": "g0022501049orl1000444cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Mobile-View",
+                                "status": "Over",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View (In-Arena)",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 5,
+                                "type": "production",
+                                "productionId": "g0022501049orl1001513cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-DR-NBC",
+                                "status": "Started",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-nbc.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-dr-nbc.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-nbc.png"
+                                },
+                                "title": "NBC (In Arena)",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-dr-nbc.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-dr-nbc.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 6,
+                                "type": "production",
+                                "productionId": "g0022501049orl1000755cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-CLE",
+                                "status": "Over",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-cle.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-cle.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-cle.png"
+                                },
+                                "title": "Cavaliers Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-cle.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-cle.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 7,
+                                "type": "production",
+                                "productionId": "g0022501049orl1000771cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-ORL",
+                                "status": "Over",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-orl.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-orl.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-orl.png"
+                                },
+                                "title": "Magic Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-orl.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-orl.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 8,
+                                "type": "production",
+                                "productionId": "g0022501049orl1000839cle",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Spanish-Radio-Team-CLE",
+                                "status": "Over",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-radio-team-cle.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-spanish-radio-team-cle.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-radio-team-cle.png"
+                                },
+                                "title": "Cavaliers Radio - Spanish",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-spanish-radio-team-cle.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-spanish-radio-team-cle.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 0,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501049orl1001457cleV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-nbc.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-nbc.png"
+                                },
+                                "title": "NBC",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-nbc.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-nbc.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 2,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501049orl1000453cleV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-cle.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-cle.png"
+                                },
+                                "title": "Cavaliers",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-cle.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-cle.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "local-home-broadcast"
+                            },
+                            {
+                                "rank": 4,
+                                "type": "l2v",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_g0022501049orl1000444cleV",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": -1,
+                                    "categoryName": "Full Games",
+                                    "categoryRank": -1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": "mobile-broadcast"
+                            },
+                            {
+                                "rank": 5,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_4F9EC6021CD46B1FA2ADEBAA0C22176D11FF9BBF",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/cle-condensed.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/cle-condensed.png"
+                                },
+                                "title": "Cavaliers Condensed",
+                                "description": "Extended home team highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/cle-condensed.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/cle-condensed.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "4:59",
+                                "videoFranchisesName": "home-best-plays"
+                            },
+                            {
+                                "rank": 6,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_678125C8EC542034507AF8C64CDC94D89C4FB71C",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/orl-condensed.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/orl-condensed.png"
+                                },
+                                "title": "Magic Condensed",
+                                "description": "Extended away team highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/orl-condensed.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/orl-condensed.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "5:00",
+                                "videoFranchisesName": "away-best-plays"
+                            },
+                            {
+                                "rank": 3,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_E6F7AC8624E6D2CE091DC6B87A93024A4A8B4E7D",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/10-minute.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/10-minute.png"
+                                },
+                                "title": "Condensed Game",
+                                "description": "Extended game highlights",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/10-minute.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/10-minute.png"
+                                },
+                                "featuredImage": "",
+                                "videoDuration": "16:40",
+                                "videoFranchisesName": "full-game-highlights"
+                            },
+                            {
+                                "rank": 2,
+                                "type": "vod",
+                                "productionId": null,
+                                "mediaKindVideoId": "NBA_62A75A1ADE680FF1EF5A9B306D7B7E2E78531B64",
+                                "uniqueName": null,
+                                "status": null,
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": null,
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/key-highlights.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/key-highlights.png"
+                                },
+                                "title": "Key Highlights",
+                                "description": "Key plays with broadcast audio",
+                                "categoryData": {
+                                    "categoryId": -2,
+                                    "categoryName": "Recaps",
+                                    "categoryRank": -2,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/key-highlights.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/key-highlights.png"
+                                },
+                                "featuredImage": "https://cdn.nba.com/manage/2026/03/e48a934a-7476-4581-a9f8-982dae4a8831_0-1.jpg",
+                                "videoDuration": "2:00",
+                                "videoFranchisesName": "wsc-key-highlights"
+                            }
+                        ],
+                        "extraMoreMenuItems": null,
+                        "gameSubtype": "",
+                        "isNeutral": false,
+                        "scoreStripHeader": {
+                            "scoreStripSpoilerHeader": "",
+                            "scoreStripNonSpoilerHeader": ""
+                        },
+                        "isTabletopGame": true,
+                        "actualStartTimeUTC": "2026-03-25T00:12:42Z",
+                        "actualEndTimeUTC": "2026-03-25T02:42:12Z",
+                        "gameDurationSeconds": 8970,
+                        "immersiveExperiences": null
+                    },
+                    "cardType": "game",
+                    "cardId": "e788f28e-8a29-b887-f93d-8466ce28cd0e"
+                }
+            ]
+        }
+    ]
+}

--- a/backend/tests/test_leaderboard_service.py
+++ b/backend/tests/test_leaderboard_service.py
@@ -9,6 +9,8 @@ from nba_wins_pool.services.nba_data_service import NBAGameStatus
 from nba_wins_pool.services.pool_season_service import TeamRosterMappings
 from nba_wins_pool.types.season_str import SeasonStr
 
+UNDRAFTED = "Undrafted"
+
 
 class FakeNbaDataService:
     def __init__(self, scoreboard_data, schedule_data, scoreboard_date):
@@ -212,3 +214,415 @@ async def test_leaderboard_returns_empty_when_no_games(monkeypatch):
 
     assert result["roster"] == []
     assert result["team"] == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by get_today_games tests
+# ---------------------------------------------------------------------------
+
+
+def _make_today_games_df():
+    """Build a DataFrame matching the sample gamecardfeed fixture (2026-03-24 Eastern)."""
+    # 4 games from the fixture, all on 2026-03-24 US/Eastern
+    rows = [
+        # DEN @ PHX — INGAME (halftime)
+        {
+            "date_time": pd.Timestamp("2026-03-25T03:00:00Z", tz="UTC"),
+            "game_id": "0022501050",
+            "game_url": "https://www.nba.com/game/den-vs-phx-0022501050",
+            "home_team": 1610612756,  # PHX
+            "home_tricode": "PHX",
+            "home_score": 57,
+            "away_team": 1610612743,  # DEN
+            "away_tricode": "DEN",
+            "away_score": 67,
+            "status": NBAGameStatus.INGAME,
+            "status_text": "Half",
+            "game_clock": "",
+        },
+        # SAC @ CHA — FINAL
+        {
+            "date_time": pd.Timestamp("2026-03-25T00:00:00Z", tz="UTC"),
+            "game_id": "0022501047",
+            "game_url": "https://www.nba.com/game/sac-vs-cha-0022501047",
+            "home_team": 1610612766,  # CHA
+            "home_tricode": "CHA",
+            "home_score": 134,
+            "away_team": 1610612758,  # SAC
+            "away_tricode": "SAC",
+            "away_score": 90,
+            "status": NBAGameStatus.FINAL,
+            "status_text": "Final",
+            "game_clock": "",
+        },
+        # NOP @ NYK — FINAL
+        {
+            "date_time": pd.Timestamp("2026-03-25T00:30:00Z", tz="UTC"),
+            "game_id": "0022501048",
+            "game_url": "https://www.nba.com/game/nop-vs-nyk-0022501048",
+            "home_team": 1610612752,  # NYK
+            "home_tricode": "NYK",
+            "home_score": 121,
+            "away_team": 1610612740,  # NOP
+            "away_tricode": "NOP",
+            "away_score": 116,
+            "status": NBAGameStatus.FINAL,
+            "status_text": "Final",
+            "game_clock": "",
+        },
+        # ORL @ CLE — FINAL
+        {
+            "date_time": pd.Timestamp("2026-03-25T01:00:00Z", tz="UTC"),
+            "game_id": "0022501049",
+            "game_url": "https://www.nba.com/game/orl-vs-cle-0022501049",
+            "home_team": 1610612739,  # CLE
+            "home_tricode": "CLE",
+            "home_score": 136,
+            "away_team": 1610612753,  # ORL
+            "away_tricode": "ORL",
+            "away_score": 131,
+            "status": NBAGameStatus.FINAL,
+            "status_text": "Final",
+            "game_clock": "",
+        },
+    ]
+    game_df = pd.DataFrame(rows)
+    game_df["date_time"] = pd.to_datetime(game_df["date_time"], utc=True).dt.tz_convert("US/Eastern")
+    game_df["winning_team"] = game_df["home_team"].where(
+        (game_df.status == NBAGameStatus.FINAL) & (game_df.home_score > game_df.away_score),
+        other=game_df["away_team"].where(game_df.status == NBAGameStatus.FINAL),
+    )
+    game_df["losing_team"] = game_df["home_team"].where(
+        (game_df.status == NBAGameStatus.FINAL) & (game_df.home_score < game_df.away_score),
+        other=game_df["away_team"].where(game_df.status == NBAGameStatus.FINAL),
+    )
+    return game_df
+
+
+def _make_today_games_service(game_df, teams_data):
+    """Construct a LeaderboardService wired to the given DataFrame and teams."""
+
+    class FakeNbaDataService:
+        def get_current_season(self):
+            return "2025-26"
+
+        async def get_game_data(self, season):
+            return game_df
+
+    class FakePoolSeasonService:
+        async def get_team_roster_mappings(self, **_):
+            df = pd.DataFrame(teams_data).set_index("team_external_id")
+            roster_names = sorted({r["roster_name"] for r in teams_data if r["roster_name"] != UNDRAFTED})
+            return TeamRosterMappings(teams_df=df, roster_names=roster_names)
+
+    return LeaderboardService(
+        db_session=None,
+        pool_repository=None,
+        roster_repository=None,
+        roster_slot_repository=None,
+        team_repository=None,
+        nba_data_service=FakeNbaDataService(),
+        pool_season_service=FakePoolSeasonService(),
+        auction_valuation_service=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_today_games tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_today_games_returns_all_four_fixture_games():
+    teams_data = [
+        {
+            "team_external_id": 1610612756,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Suns",
+            "abbreviation": "PHX",
+        },
+        {
+            "team_external_id": 1610612743,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Nuggets",
+            "abbreviation": "DEN",
+        },
+        {
+            "team_external_id": 1610612766,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Hornets",
+            "abbreviation": "CHA",
+        },
+        {
+            "team_external_id": 1610612758,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Kings",
+            "abbreviation": "SAC",
+        },
+        {
+            "team_external_id": 1610612752,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Knicks",
+            "abbreviation": "NYK",
+        },
+        {
+            "team_external_id": 1610612740,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Pelicans",
+            "abbreviation": "NOP",
+        },
+        {
+            "team_external_id": 1610612739,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Cavaliers",
+            "abbreviation": "CLE",
+        },
+        {
+            "team_external_id": 1610612753,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Magic",
+            "abbreviation": "ORL",
+        },
+    ]
+    service = _make_today_games_service(_make_today_games_df(), teams_data)
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert len(result) == 4
+    game_ids = {g["game_id"] for g in result}
+    assert game_ids == {"0022501050", "0022501047", "0022501048", "0022501049"}
+
+
+@pytest.mark.asyncio
+async def test_today_games_ingame_sorts_first():
+    """INGAME games appear before FINAL games."""
+    teams_data = [
+        {
+            "team_external_id": 1610612756,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Suns",
+            "abbreviation": "PHX",
+        },
+        {
+            "team_external_id": 1610612743,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Nuggets",
+            "abbreviation": "DEN",
+        },
+        {
+            "team_external_id": 1610612766,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Hornets",
+            "abbreviation": "CHA",
+        },
+        {
+            "team_external_id": 1610612758,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Kings",
+            "abbreviation": "SAC",
+        },
+        {
+            "team_external_id": 1610612752,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Knicks",
+            "abbreviation": "NYK",
+        },
+        {
+            "team_external_id": 1610612740,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Pelicans",
+            "abbreviation": "NOP",
+        },
+        {
+            "team_external_id": 1610612739,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Cavaliers",
+            "abbreviation": "CLE",
+        },
+        {
+            "team_external_id": 1610612753,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Magic",
+            "abbreviation": "ORL",
+        },
+    ]
+    service = _make_today_games_service(_make_today_games_df(), teams_data)
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert result[0]["game_id"] == "0022501050"  # DEN @ PHX — only INGAME game
+    assert result[0]["status"] == NBAGameStatus.INGAME
+    for game in result[1:]:
+        assert game["status"] == NBAGameStatus.FINAL
+
+
+@pytest.mark.asyncio
+async def test_today_games_scores():
+    teams_data = [
+        {
+            "team_external_id": 1610612766,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Hornets",
+            "abbreviation": "CHA",
+        },
+        {
+            "team_external_id": 1610612758,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Kings",
+            "abbreviation": "SAC",
+        },
+    ]
+    # Use only the SAC @ CHA game
+    full_df = _make_today_games_df()
+    game_df = full_df[full_df["game_id"] == "0022501047"].copy()
+    service = _make_today_games_service(game_df, teams_data)
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert len(result) == 1
+    game = result[0]
+    assert game["home_score"] == 134  # CHA
+    assert game["away_score"] == 90  # SAC
+    assert game["status_text"] == "Final"
+
+
+@pytest.mark.asyncio
+async def test_today_games_game_url():
+    teams_data = [
+        {
+            "team_external_id": 1610612756,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Suns",
+            "abbreviation": "PHX",
+        },
+        {
+            "team_external_id": 1610612743,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Nuggets",
+            "abbreviation": "DEN",
+        },
+    ]
+    full_df = _make_today_games_df()
+    game_df = full_df[full_df["game_id"] == "0022501050"].copy()
+    service = _make_today_games_service(game_df, teams_data)
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert result[0]["game_url"] == "https://www.nba.com/game/den-vs-phx-0022501050"
+
+
+@pytest.mark.asyncio
+async def test_today_games_owner_mapping():
+    """Teams drafted to a roster show the owner; undrafted teams show None."""
+    teams_data = [
+        {
+            "team_external_id": 1610612743,
+            "roster_name": "Alice",
+            "auction_price": 30.0,
+            "logo_url": "",
+            "team_name": "Nuggets",
+            "abbreviation": "DEN",
+        },
+        {
+            "team_external_id": 1610612756,
+            "roster_name": "Bob",
+            "auction_price": 25.0,
+            "logo_url": "",
+            "team_name": "Suns",
+            "abbreviation": "PHX",
+        },
+        {
+            "team_external_id": 1610612766,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Hornets",
+            "abbreviation": "CHA",
+        },
+        {
+            "team_external_id": 1610612758,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Kings",
+            "abbreviation": "SAC",
+        },
+    ]
+    full_df = _make_today_games_df()
+    game_df = full_df[full_df["game_id"].isin(["0022501050", "0022501047"])].copy()
+    service = _make_today_games_service(game_df, teams_data)
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    den_phx = next(g for g in result if g["game_id"] == "0022501050")
+    assert den_phx["away_owner"] == "Alice"  # DEN
+    assert den_phx["home_owner"] == "Bob"  # PHX
+
+    sac_cha = next(g for g in result if g["game_id"] == "0022501047")
+    assert sac_cha["away_owner"] is None  # SAC — undrafted
+    assert sac_cha["home_owner"] is None  # CHA — undrafted
+
+
+@pytest.mark.asyncio
+async def test_today_games_empty_when_no_games():
+    class EmptyNbaDataService:
+        def get_current_season(self):
+            return "2025-26"
+
+        async def get_game_data(self, season):
+            return pd.DataFrame()
+
+    class FakePoolSeasonService:
+        async def get_team_roster_mappings(self, **_):
+            df = pd.DataFrame(columns=["roster_name", "auction_price", "logo_url", "team_name", "abbreviation"])
+            df.index.name = "team_external_id"
+            return TeamRosterMappings(teams_df=df, roster_names=[])
+
+    service = LeaderboardService(
+        db_session=None,
+        pool_repository=None,
+        roster_repository=None,
+        roster_slot_repository=None,
+        team_repository=None,
+        nba_data_service=EmptyNbaDataService(),
+        pool_season_service=FakePoolSeasonService(),
+        auction_valuation_service=None,
+    )
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert result == []

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -1,6 +1,8 @@
 """Tests for NbaDataService with database-backed caching."""
 
+import json
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pandas as pd
@@ -11,6 +13,8 @@ from nba_wins_pool.models.external_data import DataFormat, ExternalData
 from nba_wins_pool.repositories.external_data_repository import ExternalDataRepository
 from nba_wins_pool.services.nba_data_service import NbaDataService
 from nba_wins_pool.types.nba_game_status import NBAGameStatus
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
@@ -288,3 +292,80 @@ class TestStoreData:
         # Assert
         mock_repo.update.assert_called_once()
         assert existing.data_json == new_data
+
+
+class TestParseGamecardfeed:
+    """Tests for _parse_gamecardfeed using the sample fixture."""
+
+    @pytest.fixture
+    def gamecardfeed_fixture(self):
+        with open(FIXTURES_DIR / "sample-nba-gamecardfeed-response.json") as f:
+            return json.load(f)
+
+    def test_parses_all_games(self, nba_service, gamecardfeed_fixture):
+        games, game_ids, scoreboard_date = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
+
+        assert len(games) == 4
+        assert len(game_ids) == 4
+
+    def test_game_ids(self, nba_service, gamecardfeed_fixture):
+        games, game_ids, _ = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
+
+        expected_ids = {"0022501050", "0022501047", "0022501048", "0022501049"}
+        assert game_ids == expected_ids
+        assert {g["game_id"] for g in games} == expected_ids
+
+    def test_scoreboard_date(self, nba_service, gamecardfeed_fixture):
+        _, _, scoreboard_date = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
+
+        # Games are at 2026-03-25 UTC, which is 2026-03-24 US/Eastern
+        from datetime import date
+
+        assert scoreboard_date == date(2026, 3, 24)
+
+    def test_game_statuses(self, nba_service, gamecardfeed_fixture):
+        games, _, _ = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
+
+        status_by_id = {g["game_id"]: g["status"] for g in games}
+        assert status_by_id["0022501050"] == NBAGameStatus.INGAME  # DEN @ PHX, halftime
+        assert status_by_id["0022501047"] == NBAGameStatus.FINAL  # SAC @ CHA
+        assert status_by_id["0022501048"] == NBAGameStatus.FINAL  # NOP @ NYK
+        assert status_by_id["0022501049"] == NBAGameStatus.FINAL  # ORL @ CLE
+
+    def test_scores(self, nba_service, gamecardfeed_fixture):
+        games, _, _ = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
+
+        cha_game = next(g for g in games if g["game_id"] == "0022501047")
+        assert cha_game["home_score"] == 134  # CHA
+        assert cha_game["away_score"] == 90  # SAC
+
+    def test_tricodes(self, nba_service, gamecardfeed_fixture):
+        games, _, _ = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
+
+        den_phx = next(g for g in games if g["game_id"] == "0022501050")
+        assert den_phx["away_tricode"] == "DEN"
+        assert den_phx["home_tricode"] == "PHX"
+
+    def test_game_url_from_share_url(self, nba_service, gamecardfeed_fixture):
+        games, _, _ = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
+
+        url_by_id = {g["game_id"]: g["game_url"] for g in games}
+        assert url_by_id["0022501050"] == "https://www.nba.com/game/den-vs-phx-0022501050"
+        assert url_by_id["0022501047"] == "https://www.nba.com/game/sac-vs-cha-0022501047"
+        assert url_by_id["0022501048"] == "https://www.nba.com/game/nop-vs-nyk-0022501048"
+        assert url_by_id["0022501049"] == "https://www.nba.com/game/orl-vs-cle-0022501049"
+
+    @pytest.mark.asyncio
+    async def test_get_game_data_includes_game_url(self, nba_service, gamecardfeed_fixture):
+        """game_url flows through get_game_data into the final DataFrame."""
+        season = nba_service.get_current_season()
+        cdn_schedule_raw = {"leagueSchedule": {"seasonYear": season, "gameDates": []}}
+
+        with patch.object(
+            nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_fixture, cdn_schedule_raw)
+        ):
+            result = await nba_service.get_game_data(season)
+
+        assert "game_url" in result.columns
+        den_phx = result[result["game_id"] == "0022501050"].iloc[0]
+        assert den_phx["game_url"] == "https://www.nba.com/game/den-vs-phx-0022501050"

--- a/frontend/src/components/pool/TodayGames.vue
+++ b/frontend/src/components/pool/TodayGames.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import type { TodayGame } from '../../types/leaderboard'
+
+const props = defineProps<{
+  games: TodayGame[]
+}>()
+
+function statusLabel(game: TodayGame): string {
+  if (game.status === 2) return game.status_text || 'LIVE'
+  if (game.status === 3) return 'Final'
+  return game.status_text || ''
+}
+
+function statusClass(game: TodayGame): string {
+  if (game.status === 2) return 'bg-green-500/20 text-green-400 border border-green-500/30'
+  if (game.status === 3) return 'bg-surface-700 text-surface-300'
+  return 'bg-blue-500/20 text-blue-400 border border-blue-500/30'
+}
+
+function isWinner(score: number | null, otherScore: number | null, status: number): boolean {
+  return status === 3 && score !== null && otherScore !== null && score > otherScore
+}
+</script>
+
+<template>
+  <div v-if="games.length === 0" class="p-6 text-center text-surface-400">
+    <i class="pi pi-calendar text-3xl mb-2 block"></i>
+    <p class="text-sm">No games today</p>
+  </div>
+  <div v-else class="flex flex-col divide-y divide-[var(--p-content-border-color)]">
+    <div v-for="game in props.games" :key="game.game_id" class="px-4 py-3">
+      <!-- Status badge + link -->
+      <div class="flex items-center justify-between mb-2">
+        <span :class="['text-xs font-semibold px-2 py-0.5 rounded-full', statusClass(game)]">
+          {{ statusLabel(game) }}
+        </span>
+        <a v-if="game.game_url" :href="game.game_url" target="_blank" rel="noopener noreferrer"
+          class="text-xs text-surface-400 hover:text-surface-200 flex items-center gap-1 transition-colors">
+          NBA.com <i class="pi pi-external-link text-[10px]"></i>
+        </a>
+      </div>
+
+      <!-- Away team -->
+      <div class="flex items-center gap-3 mb-1">
+        <img v-if="game.away_team_logo_url" :src="game.away_team_logo_url" :alt="game.away_team_tricode"
+          class="w-8 h-8 object-contain flex-shrink-0" />
+        <div v-else class="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-bold text-surface-400">
+          {{ game.away_team_tricode }}
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-semibold truncate"
+            :class="{ 'text-surface-400': game.status === 3 && !isWinner(game.away_score, game.home_score, game.status) }">
+            {{ game.away_team_name }}
+          </p>
+          <p v-if="game.away_owner" class="text-xs text-surface-400 truncate">{{ game.away_owner }}</p>
+        </div>
+        <span v-if="game.status !== 1 && game.away_score !== null" class="text-lg font-bold tabular-nums flex-shrink-0"
+          :class="{
+            'text-surface-400': game.status === 3 && !isWinner(game.away_score, game.home_score, game.status),
+          }">
+          {{ game.away_score }}
+        </span>
+      </div>
+
+      <!-- Home team -->
+      <div class="flex items-center gap-3">
+        <img v-if="game.home_team_logo_url" :src="game.home_team_logo_url" :alt="game.home_team_tricode"
+          class="w-8 h-8 object-contain flex-shrink-0" />
+        <div v-else class="w-8 h-8 flex-shrink-0 flex items-center justify-center text-xs font-bold text-surface-400">
+          {{ game.home_team_tricode }}
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-semibold truncate"
+            :class="{ 'text-surface-400': game.status === 3 && !isWinner(game.home_score, game.away_score, game.status) }">
+            {{ game.home_team_name }}
+          </p>
+          <p v-if="game.home_owner" class="text-xs text-surface-400 truncate">{{ game.home_owner }}</p>
+        </div>
+        <span v-if="game.status !== 1 && game.home_score !== null" class="text-lg font-bold tabular-nums flex-shrink-0"
+          :class="{
+            'text-surface-400': game.status === 3 && !isWinner(game.home_score, game.away_score, game.status),
+          }">
+          {{ game.home_score }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/composables/useTodayGames.ts
+++ b/frontend/src/composables/useTodayGames.ts
@@ -1,0 +1,26 @@
+import { ref } from 'vue'
+import type { TodayGame } from '@/types/leaderboard'
+
+export function useTodayGames() {
+  const games = ref<TodayGame[] | null>(null)
+  const error = ref<string | null>(null)
+  const loading = ref<boolean>(false)
+
+  async function fetchTodayGames(poolId: string, season: string) {
+    loading.value = true
+    error.value = null
+    try {
+      const url = `/api/pools/${encodeURIComponent(poolId)}/season/${encodeURIComponent(season)}/today-games`
+      const res = await fetch(url)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      games.value = await res.json()
+    } catch (e: any) {
+      console.error('Error fetching today games:', e)
+      error.value = e?.message || 'Failed to fetch today\'s games'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { games, error, loading, fetchTodayGames }
+}

--- a/frontend/src/types/leaderboard.ts
+++ b/frontend/src/types/leaderboard.ts
@@ -40,3 +40,23 @@ export interface LeaderboardResponse {
   roster: RosterRow[]
   team: TeamRow[]
 }
+
+export interface TodayGame {
+  game_id: string
+  game_url: string | null
+  status: 1 | 2 | 3 // 1=PREGAME, 2=INGAME, 3=FINAL
+  status_text: string
+  game_clock: string
+  home_team_id: number | null
+  home_team_name: string
+  home_team_tricode: string
+  home_team_logo_url: string | null
+  home_score: number | null
+  home_owner: string | null
+  away_team_id: number | null
+  away_team_name: string
+  away_team_tricode: string
+  away_team_logo_url: string | null
+  away_score: number | null
+  away_owner: string | null
+}

--- a/frontend/src/views/PoolSeasonOverview.vue
+++ b/frontend/src/views/PoolSeasonOverview.vue
@@ -11,9 +11,11 @@ import { RouterLink } from 'vue-router'
 import Panel from 'primevue/panel'
 import Card from 'primevue/card'
 import LeaderboardTable from '@/components/pool/LeaderboardTable.vue'
+import TodayGames from '@/components/pool/TodayGames.vue'
 import WinsRaceChart from '@/components/pool/WinsRaceChart.vue'
 import PlayerAvatar from '@/components/common/PlayerAvatar.vue'
 import { useLeaderboard } from '@/composables/useLeaderboard'
+import { useTodayGames } from '@/composables/useTodayGames'
 import TopBanner from '@/components/common/TopBanner.vue'
 import { useWinsRaceData } from '@/composables/useWinsRaceData'
 import { useAuctions } from '@/composables/useAuctions'
@@ -48,6 +50,13 @@ const {
   loading: chartLoading,
   fetchWinsRaceData,
 } = useWinsRaceData()
+
+const {
+  games: todayGames,
+  error: todayGamesError,
+  loading: todayGamesLoading,
+  fetchTodayGames,
+} = useTodayGames()
 
 // Resolved canonical slug for this view (may be set after resolving a UUID)
 const slugRef = ref<string | null>(null)
@@ -101,6 +110,9 @@ const rosterToEdit = ref<Roster | null>(null)
 const rosterFormName = ref('')
 const rosterFormSubmitting = ref(false)
 const rosterFormError = ref<string | null>(null)
+
+// Active tab
+const activeTab = ref<'standings' | 'today'>('standings')
 
 // Table density state controls internal table scaling (default to 'M' on all devices)
 const tableScale = ref<'S' | 'M' | 'L'>('M')
@@ -468,6 +480,7 @@ watch(
   ([id, s]) => {
     if (id) {
       fetchLeaderboard(id, s as string)
+      fetchTodayGames(id, s as string)
       fetchPoolSeasonOverview({ poolId: id, season: s as string })
       fetchAuctions({ pool_id: id })
       fetchRosters({ pool_id: id, season: s as string })
@@ -524,92 +537,147 @@ async function loadPoolSeasons(poolId: string) {
 
     <!-- Main content -->
     <div class="flex flex-col px-4 gap-4 mx-auto max-w-5xl w-full">
-      <!-- Leaderboard -->
-      <Card
-        class="border-2 rounded-xl overflow-hidden border-[var(--p-content-border-color)]"
-        :pt="{ body: 'p-0', header: 'px-4 pt-3' }"
-      >
-        <template #header>
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2">
-              <i class="pi pi-trophy"></i>
-              <p class="text-sm font-semibold">Leaderboard</p>
-            </div>
-            <div v-if="roster && team && roster.length > 0" class="flex gap-1">
-              <Button
-                label="S"
-                size="small"
-                variant="outlined"
-                :severity="tableScale === 'S' ? 'primary' : 'secondary'"
-                @click="tableScale = 'S'"
-                class="w-8 h-8 p-0"
-              />
-              <Button
-                label="M"
-                size="small"
-                variant="outlined"
-                :severity="tableScale === 'M' ? 'primary' : 'secondary'"
-                @click="tableScale = 'M'"
-                class="w-8 h-8 p-0"
-              />
-              <Button
-                label="L"
-                size="small"
-                variant="outlined"
-                :severity="tableScale === 'L' ? 'primary' : 'secondary'"
-                @click="tableScale = 'L'"
-                class="w-8 h-8 p-0"
-              />
-            </div>
-          </div>
-        </template>
-        <template #content>
-          <div v-if="leaderboardError" class="text-sm text-red-500 p-4">
-            ⚠️ {{ leaderboardError }}
-          </div>
-          <div v-else-if="leaderboardLoading" class="py-8 text-center text-surface-400">
-            <i class="pi pi-spinner pi-spin text-3xl mb-2"></i>
-            <p class="text-sm">Loading leaderboard...</p>
-          </div>
-          <div v-else-if="roster && team">
-            <LeaderboardTable
-              :roster="roster"
-              :team="team"
-              :density="tableScale"
-              maxHeight="calc(50vh - 4rem)"
-            />
-          </div>
-          <div v-else class="p-4 text-surface-400">
-            <p class="text-sm">No data available</p>
-          </div>
-        </template>
-      </Card>
 
-      <!-- Wins race chart -->
+      <!-- Tab switcher -->
+      <div class="flex border-b border-[var(--p-content-border-color)]">
+        <button
+          class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors"
+          :class="activeTab === 'standings'
+            ? 'border-primary text-primary'
+            : 'border-transparent text-surface-400 hover:text-surface-200'"
+          @click="activeTab = 'standings'"
+        >
+          <i class="pi pi-trophy mr-1.5"></i>Standings
+        </button>
+        <button
+          class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5"
+          :class="activeTab === 'today'
+            ? 'border-primary text-primary'
+            : 'border-transparent text-surface-400 hover:text-surface-200'"
+          @click="activeTab = 'today'"
+        >
+          <i class="pi pi-calendar"></i>Today's Games
+          <span
+            v-if="todayGames && todayGames.length > 0"
+            class="text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded-full"
+          >{{ todayGames.length }}</span>
+        </button>
+      </div>
+
+      <!-- Standings tab -->
+      <template v-if="activeTab === 'standings'">
+        <!-- Leaderboard -->
+        <Card
+          class="border-2 rounded-xl overflow-hidden border-[var(--p-content-border-color)]"
+          :pt="{ body: 'p-0', header: 'px-4 pt-3' }"
+        >
+          <template #header>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <i class="pi pi-trophy"></i>
+                <p class="text-sm font-semibold">Leaderboard</p>
+              </div>
+              <div v-if="roster && team && roster.length > 0" class="flex gap-1">
+                <Button
+                  label="S"
+                  size="small"
+                  variant="outlined"
+                  :severity="tableScale === 'S' ? 'primary' : 'secondary'"
+                  @click="tableScale = 'S'"
+                  class="w-8 h-8 p-0"
+                />
+                <Button
+                  label="M"
+                  size="small"
+                  variant="outlined"
+                  :severity="tableScale === 'M' ? 'primary' : 'secondary'"
+                  @click="tableScale = 'M'"
+                  class="w-8 h-8 p-0"
+                />
+                <Button
+                  label="L"
+                  size="small"
+                  variant="outlined"
+                  :severity="tableScale === 'L' ? 'primary' : 'secondary'"
+                  @click="tableScale = 'L'"
+                  class="w-8 h-8 p-0"
+                />
+              </div>
+            </div>
+          </template>
+          <template #content>
+            <div v-if="leaderboardError" class="text-sm text-red-500 p-4">
+              ⚠️ {{ leaderboardError }}
+            </div>
+            <div v-else-if="leaderboardLoading" class="py-8 text-center text-surface-400">
+              <i class="pi pi-spinner pi-spin text-3xl mb-2"></i>
+              <p class="text-sm">Loading leaderboard...</p>
+            </div>
+            <div v-else-if="roster && team">
+              <LeaderboardTable
+                :roster="roster"
+                :team="team"
+                :density="tableScale"
+                maxHeight="calc(50vh - 4rem)"
+              />
+            </div>
+            <div v-else class="p-4 text-surface-400">
+              <p class="text-sm">No data available</p>
+            </div>
+          </template>
+        </Card>
+
+        <!-- Wins race chart -->
+        <Card
+          class="border-2 rounded-xl overflow-hidden border-[var(--p-content-border-color)]"
+          :pt="{ body: 'p-0', header: 'px-4 pt-3' }"
+        >
+          <template #header>
+            <div class="flex items-center gap-2">
+              <i class="pi pi-chart-line"></i>
+              <p class="text-sm font-semibold">Wins Race</p>
+            </div>
+          </template>
+          <template #content>
+            <div v-if="chartError" class="text-sm text-red-500 p-4">⚠️ {{ chartError }}</div>
+            <div v-else-if="chartLoading" class="py-8 text-center text-surface-400">
+              <i class="pi pi-spinner pi-spin text-3xl mb-2"></i>
+              <p class="text-sm">Loading chart data...</p>
+            </div>
+            <div v-else-if="winsRaceData" class="p-4">
+              <WinsRaceChart :wins-race-data="winsRaceData" />
+            </div>
+            <div v-else class="p-4 text-surface-400">
+              <p class="text-sm">No data available</p>
+            </div>
+          </template>
+        </Card>
+      </template>
+
+      <!-- Today's Games tab -->
       <Card
+        v-if="activeTab === 'today'"
         class="border-2 rounded-xl overflow-hidden border-[var(--p-content-border-color)]"
         :pt="{ body: 'p-0', header: 'px-4 pt-3' }"
       >
         <template #header>
           <div class="flex items-center gap-2">
-            <i class="pi pi-chart-line"></i>
-            <p class="text-sm font-semibold">Wins Race</p>
+            <i class="pi pi-calendar"></i>
+            <p class="text-sm font-semibold">Today's Games</p>
           </div>
         </template>
         <template #content>
-          <div v-if="chartError" class="text-sm text-red-500 p-4">⚠️ {{ chartError }}</div>
-          <div v-else-if="chartLoading" class="py-8 text-center text-surface-400">
+          <div v-if="todayGamesError" class="text-sm text-red-500 p-4">
+            ⚠️ {{ todayGamesError }}
+          </div>
+          <div v-else-if="todayGamesLoading" class="py-8 text-center text-surface-400">
             <i class="pi pi-spinner pi-spin text-3xl mb-2"></i>
-            <p class="text-sm">Loading chart data...</p>
+            <p class="text-sm">Loading games...</p>
           </div>
-          <div v-else-if="winsRaceData" class="p-4">
-            <WinsRaceChart :wins-race-data="winsRaceData" />
-          </div>
-          <div v-else class="p-4 text-surface-400">
-            <p class="text-sm">No data available</p>
-          </div>
+          <TodayGames v-else :games="todayGames ?? []" />
         </template>
       </Card>
+
     </div>
 
     <!-- Right Drawer -->


### PR DESCRIPTION
Implements #69 .
For now just shows scores, owners, and a link to the respective NBA.com page

<img width="400" alt="localhost_5173_pools_sg_season_2025-26(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/cc8252da-e0d9-4679-ad50-be44e6b4d4b1" />
<img width="400" alt="localhost_5173_pools_sg_season_2025-26(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/0dd8828b-257c-43db-a542-691c3b509d61" />
