### PR TITLE
feat: today's games tab improvements

### DIFF
--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -35,6 +35,7 @@ from nba_wins_pool.services.pool_season_service import (
     get_pool_season_service,
 )
 from nba_wins_pool.types.season_str import SeasonStr
+from nba_wins_pool.utils.safe_cast import safe_int, safe_str
 
 UNDRAFTED_ROSTER_NAME = "Undrafted"
 
@@ -100,32 +101,7 @@ class LeaderboardService:
         if teams_df.empty:
             return {"roster": [], "team": []}
 
-        # Determine winning and losing teams for completed games (only if we have games)
-        if not game_df.empty:
-            # Map team IDs to roster names
-            for col in ["home_team", "away_team", "winning_team", "losing_team"]:
-                game_df[col.replace("_team", "_roster")] = game_df[col].map(teams_df["roster_name"], na_action="ignore")
-
-        # Generate team-level breakdown
-        team_breakdown_df = self._compute_record(game_df)
-
-        # Add all teams with 0-0 records if they haven't played yet
-        all_teams_df = pd.DataFrame(
-            [
-                {"name": row["roster_name"], "team": team_id, "wins": 0, "losses": 0}
-                for team_id, row in teams_df.iterrows()
-            ]
-        )
-        all_teams_df = pd.DataFrame(
-            [
-                {"name": row["roster_name"], "team": team_id, "wins": 0, "losses": 0}
-                for team_id, row in teams_df.iterrows()
-            ]
-        )
-        team_breakdown_df = pd.concat([all_teams_df, team_breakdown_df], ignore_index=True)
-        team_breakdown_df = team_breakdown_df.groupby(["name", "team"], as_index=False).agg(
-            {"wins": "sum", "losses": "sum"}
-        )
+        team_breakdown_df = self._build_team_breakdown(game_df, teams_df)
 
         # Merge team metadata (logo_url, auction_price) in one operation
         team_breakdown_df = team_breakdown_df.merge(
@@ -346,25 +322,27 @@ class LeaderboardService:
         )
         teams_df = mappings.teams_df
 
-        def get_team_info(team_id):
-            if pd.isna(team_id):
-                return None
-            team_id = int(team_id)
-            return teams_df.loc[team_id] if team_id in teams_df.index else None
+        team_breakdown_df = self._build_team_breakdown(game_df, teams_df)
 
-        def safe_int(val):
-            return None if pd.isna(val) else int(val)
+        # roster_name -> total season wins
+        roster_standings_df = self._compute_roster_standings(team_breakdown_df)
+        roster_season_wins: dict[str, int] = {
+            row["name"]: int(row["wins"]) for _, row in roster_standings_df.iterrows()
+        }
 
-        def safe_str(val):
-            return "" if pd.isna(val) else str(val)
+        # roster_name -> (today_wins, today_losses) from completed games on scoreboard_date
+        today_record_df = self._compute_record(game_df, scoreboard_date, offset=0)
+        today_roster_record: dict[str, tuple[int, int]] = {
+            row["name"]: (int(row["wins"]), int(row["losses"]))
+            for _, row in today_record_df.groupby("name")[["wins", "losses"]].sum().reset_index().iterrows()
+        }
 
         status_sort = {NBAGameStatus.INGAME: 0, NBAGameStatus.PREGAME: 1, NBAGameStatus.FINAL: 2}
 
         result = []
         for _, game in today_df.iterrows():
-            home_info = get_team_info(game["home_team"])
-            away_info = get_team_info(game["away_team"])
-
+            home_id = safe_int(game["home_team"])
+            away_id = safe_int(game["away_team"])
             result.append(
                 {
                     "game_id": game["game_id"],
@@ -372,31 +350,79 @@ class LeaderboardService:
                     "status": int(game["status"]),
                     "status_text": safe_str(game["status_text"]),
                     "game_clock": safe_str(game["game_clock"]),
-                    "home_team_id": safe_int(game["home_team"]),
-                    "home_team_name": home_info["team_name"]
-                    if home_info is not None
-                    else safe_str(game["home_tricode"]),
-                    "home_team_tricode": safe_str(game["home_tricode"]),
-                    "home_team_logo_url": home_info["logo_url"] if home_info is not None else None,
-                    "home_score": safe_int(game["home_score"]),
-                    "home_owner": home_info["roster_name"]
-                    if home_info is not None and home_info["roster_name"] != UNDRAFTED_ROSTER_NAME
-                    else None,
-                    "away_team_id": safe_int(game["away_team"]),
-                    "away_team_name": away_info["team_name"]
-                    if away_info is not None
-                    else safe_str(game["away_tricode"]),
-                    "away_team_tricode": safe_str(game["away_tricode"]),
-                    "away_team_logo_url": away_info["logo_url"] if away_info is not None else None,
-                    "away_score": safe_int(game["away_score"]),
-                    "away_owner": away_info["roster_name"]
-                    if away_info is not None and away_info["roster_name"] != UNDRAFTED_ROSTER_NAME
-                    else None,
+                    **self._build_game_side("home", game, home_id, teams_df, roster_season_wins, today_roster_record),
+                    **self._build_game_side("away", game, away_id, teams_df, roster_season_wins, today_roster_record),
                 }
             )
 
         result.sort(key=lambda g: (status_sort.get(g["status"], 99), g["game_id"] or ""))
         return result
+
+    def _build_team_breakdown(self, game_df: pd.DataFrame, teams_df: pd.DataFrame) -> pd.DataFrame:
+        """Map roster columns onto game_df and compute wins/losses for every team.
+
+        Returns a DataFrame with columns: name, team (team_id), wins, losses.
+        Every team in teams_df is guaranteed to appear with at least a 0-0 record.
+        """
+        for col in ["home_team", "away_team", "winning_team", "losing_team"]:
+            game_df[col.replace("_team", "_roster")] = game_df[col].map(teams_df["roster_name"], na_action="ignore")
+
+        team_breakdown_df = self._compute_record(game_df)
+        all_teams_df = pd.DataFrame(
+            [
+                {"name": row["roster_name"], "team": team_id, "wins": 0, "losses": 0}
+                for team_id, row in teams_df.iterrows()
+            ]
+        )
+        team_breakdown_df = pd.concat([all_teams_df, team_breakdown_df], ignore_index=True)
+        team_breakdown_df = team_breakdown_df.groupby(["name", "team"], as_index=False).agg(
+            {"wins": "sum", "losses": "sum"}
+        )
+        team_breakdown_df["wins"] = team_breakdown_df["wins"].astype(int)
+        team_breakdown_df["losses"] = team_breakdown_df["losses"].astype(int)
+        return team_breakdown_df
+
+    def _build_roster_info(self, roster_standings_df: pd.DataFrame) -> dict[str, dict]:
+        """Build a roster-name-keyed lookup of wins, losses, rank, and rank_tied."""
+        rank_counts = roster_standings_df["rank"].value_counts()
+        return {
+            row["name"]: {
+                "wins": int(row["wins"]),
+                "losses": int(row["losses"]),
+                "rank": int(row["rank"]) if not pd.isna(row["rank"]) else None,
+                "rank_tied": bool(rank_counts.get(row["rank"], 0) > 1) if not pd.isna(row["rank"]) else False,
+            }
+            for _, row in roster_standings_df.iterrows()
+        }
+
+    def _build_game_side(
+        self,
+        side: str,
+        game,
+        team_id: int | None,
+        teams_df: pd.DataFrame,
+        roster_season_wins: dict[str, int],
+        today_roster_record: dict[str, tuple[int, int]],
+    ) -> dict:
+        """Build the home or away half of a today-game dict."""
+        team_info = teams_df.loc[team_id] if team_id is not None and team_id in teams_df.index else None
+        owner = (
+            team_info["roster_name"]
+            if team_info is not None and team_info["roster_name"] != UNDRAFTED_ROSTER_NAME
+            else None
+        )
+        today_rec = today_roster_record.get(owner) if owner else None
+        return {
+            f"{side}_team_id": team_id,
+            f"{side}_team_name": team_info["team_name"] if team_info is not None else safe_str(game[f"{side}_tricode"]),
+            f"{side}_team_tricode": safe_str(game[f"{side}_tricode"]),
+            f"{side}_team_logo_url": team_info["logo_url"] if team_info is not None else None,
+            f"{side}_score": safe_int(game[f"{side}_score"]),
+            f"{side}_owner": owner,
+            f"{side}_owner_wins": roster_season_wins.get(owner) if owner else None,
+            f"{side}_owner_today_wins": today_rec[0] if today_rec is not None else None,
+            f"{side}_owner_today_losses": today_rec[1] if today_rec is not None else None,
+        }
 
     def _compute_roster_standings(self, team_breakdown_df: pd.DataFrame) -> pd.DataFrame:
         """Compute roster-level standings from team breakdown.

--- a/backend/src/nba_wins_pool/utils/safe_cast.py
+++ b/backend/src/nba_wins_pool/utils/safe_cast.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+
+def safe_int(val) -> int | None:
+    return None if pd.isna(val) else int(val)
+
+
+def safe_str(val) -> str:
+    return "" if pd.isna(val) else str(val)

--- a/frontend/src/components/pool/TodayGames.vue
+++ b/frontend/src/components/pool/TodayGames.vue
@@ -20,6 +20,13 @@ function statusClass(game: TodayGame): string {
 function isWinner(score: number | null, otherScore: number | null, status: number): boolean {
   return status === 3 && score !== null && otherScore !== null && score > otherScore
 }
+
+function todayRecord(wins: number | null, losses: number | null): string | null {
+  if (wins === null || losses === null) return null
+  return `${wins}-${losses}`
+}
+
+
 </script>
 
 <template>
@@ -52,7 +59,13 @@ function isWinner(score: number | null, otherScore: number | null, status: numbe
             :class="{ 'text-surface-400': game.status === 3 && !isWinner(game.away_score, game.home_score, game.status) }">
             {{ game.away_team_name }}
           </p>
-          <p v-if="game.away_owner" class="text-xs text-surface-400 truncate">{{ game.away_owner }}</p>
+          <p v-if="game.away_owner" class="text-xs text-surface-400 truncate">
+            {{ game.away_owner }}
+            <template v-if="game.away_owner_wins !== null">
+              <span class="text-surface-500"> · {{ game.away_owner_wins }} Wins</span>
+              <span v-if="todayRecord(game.away_owner_today_wins, game.away_owner_today_losses)" class="text-surface-500"> · {{ todayRecord(game.away_owner_today_wins, game.away_owner_today_losses) }} Today</span>
+            </template>
+          </p>
         </div>
         <span v-if="game.status !== 1 && game.away_score !== null" class="text-lg font-bold tabular-nums flex-shrink-0"
           :class="{
@@ -74,7 +87,13 @@ function isWinner(score: number | null, otherScore: number | null, status: numbe
             :class="{ 'text-surface-400': game.status === 3 && !isWinner(game.home_score, game.away_score, game.status) }">
             {{ game.home_team_name }}
           </p>
-          <p v-if="game.home_owner" class="text-xs text-surface-400 truncate">{{ game.home_owner }}</p>
+          <p v-if="game.home_owner" class="text-xs text-surface-400 truncate">
+            {{ game.home_owner }}
+            <template v-if="game.home_owner_wins !== null">
+              <span class="text-surface-500"> · {{ game.home_owner_wins }} Wins</span>
+              <span v-if="todayRecord(game.home_owner_today_wins, game.home_owner_today_losses)" class="text-surface-500"> · {{ todayRecord(game.home_owner_today_wins, game.home_owner_today_losses) }} Today</span>
+            </template>
+          </p>
         </div>
         <span v-if="game.status !== 1 && game.home_score !== null" class="text-lg font-bold tabular-nums flex-shrink-0"
           :class="{

--- a/frontend/src/composables/useLeaderboard.ts
+++ b/frontend/src/composables/useLeaderboard.ts
@@ -6,6 +6,7 @@ export function useLeaderboard() {
   const team = ref<TeamRow[] | null>(null)
   const error = ref<string | null>(null)
   const loading = ref<boolean>(false)
+  const lastUpdated = ref<Date | null>(null)
 
   async function fetchLeaderboard(poolId: string, season: string) {
     loading.value = true
@@ -17,6 +18,7 @@ export function useLeaderboard() {
       const data: LeaderboardResponse = await res.json()
       roster.value = data.roster
       team.value = data.team
+      lastUpdated.value = new Date()
     } catch (e: any) {
       console.error('Error fetching leaderboard:', e)
       error.value = e?.message || 'Failed to fetch leaderboard'
@@ -25,5 +27,5 @@ export function useLeaderboard() {
     }
   }
 
-  return { roster, team, error, loading, fetchLeaderboard }
+  return { roster, team, error, loading, lastUpdated, fetchLeaderboard }
 }

--- a/frontend/src/types/leaderboard.ts
+++ b/frontend/src/types/leaderboard.ts
@@ -53,10 +53,16 @@ export interface TodayGame {
   home_team_logo_url: string | null
   home_score: number | null
   home_owner: string | null
+  home_owner_wins: number | null
+  home_owner_today_wins: number | null
+  home_owner_today_losses: number | null
   away_team_id: number | null
   away_team_name: string
   away_team_tricode: string
   away_team_logo_url: string | null
   away_score: number | null
   away_owner: string | null
+  away_owner_wins: number | null
+  away_owner_today_wins: number | null
+  away_owner_today_losses: number | null
 }

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -89,6 +89,25 @@ export function formatUTCDate(
 }
 
 /**
+ * Format a Date as a human-readable relative time string (e.g., "5 seconds ago").
+ *
+ * @param date - The date to compare against now
+ * @param now - The current time (defaults to new Date())
+ * @returns Human-readable string like "just now", "5 seconds ago", "2 hours ago"
+ */
+export function timeAgo(date: Date, now: Date = new Date()): string {
+  const seconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+  if (seconds < 5) return 'just now'
+  if (seconds < 60) return `${seconds} seconds ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const days = Math.floor(hours / 24)
+  return `${days} day${days === 1 ? '' : 's'} ago`
+}
+
+/**
  * Format a timestamp from the backend as a localized date and time string.
  *
  * @param timestamp - ISO timestamp string from backend

--- a/frontend/src/views/PoolSeasonOverview.vue
+++ b/frontend/src/views/PoolSeasonOverview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useConfirm } from 'primevue/useconfirm'
 import Drawer from 'primevue/drawer'
@@ -28,6 +28,7 @@ import PoolForm from '@/components/pool/PoolForm.vue'
 import AuctionForm from '@/components/pool/AuctionForm.vue'
 import SeasonForm, { type SeasonFormData } from '@/components/pool/SeasonForm.vue'
 import { getCurrentSeason } from '@/utils/season'
+import { timeAgo } from '@/utils/time'
 import type { AuctionCreate, AuctionUpdate, Roster, PoolUpdate } from '@/types/pool'
 import { isUuid } from '@/utils/ids'
 import Message from 'primevue/message'
@@ -41,8 +42,17 @@ const {
   team,
   error: leaderboardError,
   loading: leaderboardLoading,
+  lastUpdated: leaderboardLastUpdated,
   fetchLeaderboard,
 } = useLeaderboard()
+
+const now = ref(new Date())
+const nowInterval = setInterval(() => { now.value = new Date() }, 10_000)
+onUnmounted(() => clearInterval(nowInterval))
+
+const leaderboardTimeAgo = computed(() =>
+  leaderboardLastUpdated.value ? timeAgo(leaderboardLastUpdated.value, now.value) : null,
+)
 
 const {
   winsRaceData,
@@ -111,8 +121,14 @@ const rosterFormName = ref('')
 const rosterFormSubmitting = ref(false)
 const rosterFormError = ref<string | null>(null)
 
-// Active tab
-const activeTab = ref<'standings' | 'today'>('standings')
+// Active tab — synced with ?tab= query param for linkability and refresh persistence
+const TAB_VALUES = ['standings', 'today'] as const
+type Tab = (typeof TAB_VALUES)[number]
+const routeTab = route.query.tab
+const activeTab = ref<Tab>(TAB_VALUES.includes(routeTab as Tab) ? (routeTab as Tab) : 'standings')
+watch(activeTab, (tab) => {
+  router.replace({ query: { ...route.query, tab } })
+})
 
 // Table density state controls internal table scaling (default to 'M' on all devices)
 const tableScale = ref<'S' | 'M' | 'L'>('M')
@@ -541,7 +557,7 @@ async function loadPoolSeasons(poolId: string) {
       <!-- Tab switcher -->
       <div class="flex border-b border-[var(--p-content-border-color)]">
         <button
-          class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors"
+          class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors sm:flex-none flex-1"
           :class="activeTab === 'standings'
             ? 'border-primary text-primary'
             : 'border-transparent text-surface-400 hover:text-surface-200'"
@@ -550,7 +566,7 @@ async function loadPoolSeasons(poolId: string) {
           <i class="pi pi-trophy mr-1.5"></i>Standings
         </button>
         <button
-          class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center gap-1.5"
+          class="px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors flex items-center justify-center gap-1.5 sm:flex-none flex-1"
           :class="activeTab === 'today'
             ? 'border-primary text-primary'
             : 'border-transparent text-surface-400 hover:text-surface-200'"
@@ -573,9 +589,12 @@ async function loadPoolSeasons(poolId: string) {
         >
           <template #header>
             <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <i class="pi pi-trophy"></i>
-                <p class="text-sm font-semibold">Leaderboard</p>
+              <div class="flex flex-col gap-0.5">
+                <div class="flex items-center gap-2">
+                  <i class="pi pi-trophy"></i>
+                  <p class="text-sm font-semibold">Leaderboard</p>
+                </div>
+                <p v-if="leaderboardTimeAgo" class="text-xs text-surface-400">Updated {{ leaderboardTimeAgo }}</p>
               </div>
               <div v-if="roster && team && roster.length > 0" class="flex gap-1">
                 <Button
@@ -661,9 +680,12 @@ async function loadPoolSeasons(poolId: string) {
         :pt="{ body: 'p-0', header: 'px-4 pt-3' }"
       >
         <template #header>
-          <div class="flex items-center gap-2">
-            <i class="pi pi-calendar"></i>
-            <p class="text-sm font-semibold">Today's Games</p>
+          <div class="flex flex-col gap-0.5">
+            <div class="flex items-center gap-2">
+              <i class="pi pi-calendar"></i>
+              <p class="text-sm font-semibold">Today's Games</p>
+            </div>
+            <p v-if="leaderboardTimeAgo" class="text-xs text-surface-400">Updated {{ leaderboardTimeAgo }}</p>
           </div>
         </template>
         <template #content>


### PR DESCRIPTION
- Added wins and today's record next to roster name
- Added time since last refresh/update
- On mobile, tabs evenly split across full width
- Name of tab is now a query parameter so tabs can be directly linked to and don't change on reload

<img width="400" alt="localhost_5173_pools_sg_season_2025-26_tab=standings(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/2967b528-c684-4058-b9db-9471b2425f94" />
<img width="400" alt="localhost_5173_pools_sg_season_2025-26_tab=standings(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/72e05907-1d69-476a-afd9-9a7ed8426a27" />

