### PR TITLE
feat: pregame improvements for Today's Games tab

### DIFF
--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -356,6 +356,9 @@ class LeaderboardService:
                     "game_time": game["date_time"].tz_convert("UTC").strftime("%Y-%m-%dT%H:%M:%S")
                     if pd.notna(game.get("date_time"))
                     else None,
+                    "arena_name": game.get("arena_name") or None,
+                    "arena_city": game.get("arena_city") or None,
+                    "arena_state": game.get("arena_state") or None,
                     **self._build_game_side("home", game, home_id, teams_df, roster_season_wins, today_roster_record),
                     **self._build_game_side("away", game, away_id, teams_df, roster_season_wins, today_roster_record),
                 }

--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -1,11 +1,9 @@
-import logging
 from datetime import date, timedelta
 from typing import Any
 from uuid import UUID
 
 import numpy as np
 import pandas as pd
-import requests
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,7 +37,6 @@ from nba_wins_pool.services.pool_season_service import (
 from nba_wins_pool.types.season_str import SeasonStr
 from nba_wins_pool.utils.safe_cast import safe_int, safe_str
 
-logger = logging.getLogger(__name__)
 UNDRAFTED_ROSTER_NAME = "Undrafted"
 
 
@@ -364,54 +361,13 @@ class LeaderboardService:
                 }
             )
 
-        odds_map = self._fetch_fanduel_moneyline_odds()
+        odds_map = self.nba_data_service.get_fanduel_moneyline_odds()
         for game in result:
             odds = odds_map.get(game["game_id"])
             game["home_win_pct"] = odds["home"] if odds else None
             game["away_win_pct"] = odds["away"] if odds else None
 
         result.sort(key=lambda g: (status_sort.get(g["status"], 99), g["game_id"] or ""))
-        return result
-
-    def _fetch_fanduel_moneyline_odds(self) -> dict[str, dict[str, float]]:
-        """Fetch vig-adjusted FanDuel moneyline win probabilities for today's games.
-
-        Returns:
-            Dict mapping game_id -> {"home": float, "away": float} win probabilities,
-            or empty dict if the request fails.
-        """
-        url = "https://cdn.nba.com/static/json/liveData/odds/odds_todaysGames.json"
-        try:
-            response = requests.get(url, timeout=10)
-            response.raise_for_status()
-            data = response.json()
-        except Exception:
-            logger.warning("Failed to fetch FanDuel odds from %s", url, exc_info=True)
-            return {}
-
-        result = {}
-        for game in data.get("games", []):
-            game_id = str(game.get("gameId", ""))
-            moneyline = next((m for m in game.get("markets", []) if m.get("name") == "2way"), None)
-            if not moneyline:
-                continue
-            fanduel = next((b for b in moneyline.get("books", []) if b.get("name") == "FanDuel"), None)
-            if not fanduel:
-                continue
-            outcomes = fanduel.get("outcomes", [])
-            home_out = next((o for o in outcomes if o.get("type") == "home"), None)
-            away_out = next((o for o in outcomes if o.get("type") == "away"), None)
-            if not home_out or not away_out:
-                continue
-            home_odds = home_out.get("odds")
-            away_odds = away_out.get("odds")
-            if not home_odds or not away_odds:
-                continue
-            raw_home = 1 / float(home_odds)
-            raw_away = 1 / float(away_odds)
-            total = raw_home + raw_away
-            result[game_id] = {"home": raw_home / total, "away": raw_away / total}
-
         return result
 
     def _build_team_breakdown(self, game_df: pd.DataFrame, teams_df: pd.DataFrame) -> pd.DataFrame:

--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -356,6 +356,7 @@ class LeaderboardService:
                     "arena_name": game.get("arena_name") or None,
                     "arena_city": game.get("arena_city") or None,
                     "arena_state": game.get("arena_state") or None,
+                    "national_broadcaster_logos": game.get("national_broadcaster_logos") or None,
                     **self._build_game_side("home", game, home_id, teams_df, roster_season_wins, today_roster_record),
                     **self._build_game_side("away", game, away_id, teams_df, roster_season_wins, today_roster_record),
                 }

--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -1,9 +1,11 @@
+import logging
 from datetime import date, timedelta
 from typing import Any
 from uuid import UUID
 
 import numpy as np
 import pandas as pd
+import requests
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -37,6 +39,7 @@ from nba_wins_pool.services.pool_season_service import (
 from nba_wins_pool.types.season_str import SeasonStr
 from nba_wins_pool.utils.safe_cast import safe_int, safe_str
 
+logger = logging.getLogger(__name__)
 UNDRAFTED_ROSTER_NAME = "Undrafted"
 
 
@@ -350,12 +353,62 @@ class LeaderboardService:
                     "status": int(game["status"]),
                     "status_text": safe_str(game["status_text"]),
                     "game_clock": safe_str(game["game_clock"]),
+                    "game_time": game["date_time"].tz_convert("UTC").strftime("%Y-%m-%dT%H:%M:%S")
+                    if pd.notna(game.get("date_time"))
+                    else None,
                     **self._build_game_side("home", game, home_id, teams_df, roster_season_wins, today_roster_record),
                     **self._build_game_side("away", game, away_id, teams_df, roster_season_wins, today_roster_record),
                 }
             )
 
+        odds_map = self._fetch_fanduel_moneyline_odds()
+        for game in result:
+            odds = odds_map.get(game["game_id"])
+            game["home_win_pct"] = odds["home"] if odds else None
+            game["away_win_pct"] = odds["away"] if odds else None
+
         result.sort(key=lambda g: (status_sort.get(g["status"], 99), g["game_id"] or ""))
+        return result
+
+    def _fetch_fanduel_moneyline_odds(self) -> dict[str, dict[str, float]]:
+        """Fetch vig-adjusted FanDuel moneyline win probabilities for today's games.
+
+        Returns:
+            Dict mapping game_id -> {"home": float, "away": float} win probabilities,
+            or empty dict if the request fails.
+        """
+        url = "https://cdn.nba.com/static/json/liveData/odds/odds_todaysGames.json"
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+        except Exception:
+            logger.warning("Failed to fetch FanDuel odds from %s", url, exc_info=True)
+            return {}
+
+        result = {}
+        for game in data.get("games", []):
+            game_id = str(game.get("gameId", ""))
+            moneyline = next((m for m in game.get("markets", []) if m.get("name") == "2way"), None)
+            if not moneyline:
+                continue
+            fanduel = next((b for b in moneyline.get("books", []) if b.get("name") == "FanDuel"), None)
+            if not fanduel:
+                continue
+            outcomes = fanduel.get("outcomes", [])
+            home_out = next((o for o in outcomes if o.get("type") == "home"), None)
+            away_out = next((o for o in outcomes if o.get("type") == "away"), None)
+            if not home_out or not away_out:
+                continue
+            home_odds = home_out.get("odds")
+            away_odds = away_out.get("odds")
+            if not home_odds or not away_odds:
+                continue
+            raw_home = 1 / float(home_odds)
+            raw_away = 1 / float(away_odds)
+            total = raw_home + raw_away
+            result[game_id] = {"home": raw_home / total, "away": raw_away / total}
+
         return result
 
     def _build_team_breakdown(self, game_df: pd.DataFrame, teams_df: pd.DataFrame) -> pd.DataFrame:

--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -164,19 +164,16 @@ class NbaDataService:
             if period >= 4 and seconds_remaining == 0 and home_score - away_score != 0:
                 status = NBAGameStatus.FINAL
 
-        game_id = game.get("gameId")
-        away_slug = game.get("awayTeam", {}).get("teamSlug")
-        home_slug = game.get("homeTeam", {}).get("teamSlug")
-        game_url = game.get("shareUrl") or (
-            f"https://www.nba.com/game/{away_slug}-vs-{home_slug}-{game_id}"
-            if away_slug and home_slug and game_id
-            else None
-        )
+        national_broadcasters = game.get("broadcasters", {}).get("nationalBroadcasters", [])
+        national_broadcaster_logos = [
+            b["broadcasterLogoUrlDarkSvg"] for b in national_broadcasters if b.get("broadcasterLogoUrlDarkSvg")
+        ]
 
         return {
             "date_time": game_timestamp,
-            "game_id": game_id,
-            "game_url": game_url,
+            "game_id": game.get("gameId"),
+            "game_url": game.get("shareUrl"),
+            "national_broadcaster_logos": national_broadcaster_logos or None,
             "home_team": game.get("homeTeam", {}).get("teamId"),
             "home_tricode": game.get("homeTeam", {}).get("teamTricode"),
             "home_score": home_score,
@@ -291,7 +288,15 @@ class NbaDataService:
 
             # Overlay live scores/status/clock from gamecardfeed onto the schedule rows
             # for today's games — those fields update in real time, unlike schedule metadata.
-            live_cols = ["status", "status_text", "game_clock", "home_score", "away_score", "game_url"]
+            live_cols = [
+                "status",
+                "status_text",
+                "game_clock",
+                "home_score",
+                "away_score",
+                "game_url",
+                "national_broadcaster_logos",
+            ]
             if live_games and not game_df.empty:
                 live_df = pd.DataFrame(live_games).set_index("game_id")[live_cols]
                 mask = game_df["game_id"].isin(live_df.index)

--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -164,10 +164,19 @@ class NbaDataService:
             if period >= 4 and seconds_remaining == 0 and home_score - away_score != 0:
                 status = NBAGameStatus.FINAL
 
+        game_id = game.get("gameId")
+        away_slug = game.get("awayTeam", {}).get("teamSlug")
+        home_slug = game.get("homeTeam", {}).get("teamSlug")
+        game_url = game.get("shareUrl") or (
+            f"https://www.nba.com/game/{away_slug}-vs-{home_slug}-{game_id}"
+            if away_slug and home_slug and game_id
+            else None
+        )
+
         return {
             "date_time": game_timestamp,
-            "game_id": game.get("gameId"),
-            "game_url": game.get("shareUrl"),
+            "game_id": game_id,
+            "game_url": game_url,
             "home_team": game.get("homeTeam", {}).get("teamId"),
             "home_tricode": game.get("homeTeam", {}).get("teamTricode"),
             "home_score": home_score,
@@ -177,6 +186,9 @@ class NbaDataService:
             "status_text": game.get("gameStatusText"),
             "game_clock": game.get("gameClock"),
             "status": status,
+            "arena_name": game.get("arenaName"),
+            "arena_city": game.get("arenaCity"),
+            "arena_state": game.get("arenaState"),
         }
 
     def _parse_gamecardfeed(self, raw_response: dict) -> tuple[list[dict], set[str], date]:
@@ -241,7 +253,7 @@ class NbaDataService:
             if (
                 len(scoreboard_gameids) == 0
                 and scoreboard_date
-                and pd.to_datetime(game_date["gameDate"], format="ISO8601").date() > scoreboard_date
+                and pd.to_datetime(game_date["gameDate"], format="mixed").date() > scoreboard_date
             ):
                 break
             for game in game_date["games"]:
@@ -271,9 +283,24 @@ class NbaDataService:
         if season_year == self.get_current_season():
             raw_gamecardfeed, raw_schedule = await asyncio.to_thread(self._fetch_current_season_raw)
             live_games, game_ids, scoreboard_date = self._parse_gamecardfeed(raw_gamecardfeed)
-            schedule = self._parse_schedule(raw_schedule, scoreboard_gameids=game_ids, scoreboard_date=scoreboard_date)
-            schedule.extend(live_games)
+
+            # Parse the full schedule up to and including scoreboard_date so that today's
+            # games are present with their schedule metadata (arena, etc.)
+            schedule = self._parse_schedule(raw_schedule, scoreboard_date=scoreboard_date)
             game_df = pd.DataFrame(schedule)
+
+            # Overlay live scores/status/clock from gamecardfeed onto the schedule rows
+            # for today's games — those fields update in real time, unlike schedule metadata.
+            live_cols = ["status", "status_text", "game_clock", "home_score", "away_score", "game_url"]
+            if live_games and not game_df.empty:
+                live_df = pd.DataFrame(live_games).set_index("game_id")[live_cols]
+                mask = game_df["game_id"].isin(live_df.index)
+                for col in live_cols:
+                    live_values = game_df.loc[mask, "game_id"].map(live_df[col])
+                    # Prefer live value; fall back to schedule value when live is null.
+                    game_df.loc[mask, col] = live_values.where(live_values.notna(), game_df.loc[mask, col])
+            elif live_games:
+                game_df = pd.DataFrame(live_games)
         else:
             game_df = pd.DataFrame(await self.get_historical_schedule_cached(season_year))
 

--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -318,6 +318,47 @@ class NbaDataService:
         )
         return game_df
 
+    def get_fanduel_moneyline_odds(self) -> dict[str, dict[str, float]]:
+        """Fetch vig-adjusted FanDuel moneyline win probabilities for today's games.
+
+        Returns:
+            Dict mapping game_id -> {"home": float, "away": float} win probabilities,
+            or empty dict if the request fails.
+        """
+        url = "https://cdn.nba.com/static/json/liveData/odds/odds_todaysGames.json"
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+        except Exception:
+            logger.warning("Failed to fetch FanDuel odds from %s", url, exc_info=True)
+            return {}
+
+        result = {}
+        for game in data.get("games", []):
+            game_id = str(game.get("gameId", ""))
+            moneyline = next((m for m in game.get("markets", []) if m.get("name") == "2way"), None)
+            if not moneyline:
+                continue
+            fanduel = next((b for b in moneyline.get("books", []) if b.get("name") == "FanDuel"), None)
+            if not fanduel:
+                continue
+            outcomes = fanduel.get("outcomes", [])
+            home_out = next((o for o in outcomes if o.get("type") == "home"), None)
+            away_out = next((o for o in outcomes if o.get("type") == "away"), None)
+            if not home_out or not away_out:
+                continue
+            home_odds = home_out.get("odds")
+            away_odds = away_out.get("odds")
+            if not home_odds or not away_odds:
+                continue
+            raw_home = 1 / float(home_odds)
+            raw_away = 1 / float(away_odds)
+            total = raw_home + raw_away
+            result[game_id] = {"home": raw_home / total, "away": raw_away / total}
+
+        return result
+
     async def _store_data(self, key: str, data: dict) -> None:
         """Store data in database cache (generic helper).
 

--- a/backend/tests/fixtures/sample-nba-gamecardfeed-response.json
+++ b/backend/tests/fixtures/sample-nba-gamecardfeed-response.json
@@ -30,6 +30,635 @@
                 {
                     "cardData": {
                         "heroConfiguration": {
+                            "headline": "Hawks @ Pistons",
+                            "subhead": "",
+                            "image": {
+                                "imageUrl": "https://cdn.nba.com/manage/2026/03/atl_vs_det_game_recap_032526_thumbnail.png"
+                            },
+                            "video": null,
+                            "gameRecap": null,
+                            "headlineNoSpoilers": "Hawks @ Pistons"
+                        },
+                        "gameId": "0022501051",
+                        "leagueId": "00",
+                        "seasonYear": "2025-26",
+                        "seasonType": "Regular Season",
+                        "dailyGameRank": "1",
+                        "period": 0,
+                        "homeTeam": {
+                            "teamId": 1610612765,
+                            "teamName": "Pistons",
+                            "wins": 52,
+                            "losses": 19,
+                            "teamSubtitle": "52-19",
+                            "score": 0,
+                            "timeoutsRemaining": 0,
+                            "inBonus": false,
+                            "teamTricode": "DET",
+                            "teamSlug": "pistons",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1631105",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 0
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1630595,
+                                "name": "Cade Cunningham",
+                                "jerseyNum": "2",
+                                "position": "G",
+                                "teamTricode": "DET",
+                                "playerSlug": "cade-cunningham",
+                                "points": "24.5",
+                                "rebounds": "5.6",
+                                "assists": "9.9",
+                                "blocks": null,
+                                "steals": null
+                            }
+                        },
+                        "awayTeam": {
+                            "teamId": 1610612737,
+                            "teamName": "Hawks",
+                            "wins": 40,
+                            "losses": 32,
+                            "teamSubtitle": "40-32",
+                            "score": 0,
+                            "timeoutsRemaining": 0,
+                            "inBonus": false,
+                            "teamTricode": "ATL",
+                            "teamSlug": "hawks",
+                            "specialInfoPrefix": null,
+                            "marqueePlayer": "1630552",
+                            "periods": [
+                                {
+                                    "period": 1,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 2,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 3,
+                                    "score": 0
+                                },
+                                {
+                                    "period": 4,
+                                    "score": 0
+                                }
+                            ],
+                            "teamLeader": {
+                                "personId": 1630552,
+                                "name": "Jalen Johnson",
+                                "jerseyNum": "1",
+                                "position": "F",
+                                "teamTricode": "ATL",
+                                "playerSlug": "jalen-johnson",
+                                "points": "22.7",
+                                "rebounds": "10.4",
+                                "assists": "8",
+                                "blocks": null,
+                                "steals": null
+                            }
+                        },
+                        "seasonLeadersFlag": 0,
+                        "gameClock": "--:--",
+                        "gameStatus": 1,
+                        "gameStatusText": "7:00 pm ET",
+                        "gameBreakStatus": "",
+                        "gameState": 1,
+                        "duration": 0,
+                        "gameTimeEastern": "2026-03-25T19:00:00Z",
+                        "gameTimeUtc": "2026-03-25T23:00:00Z",
+                        "info": "",
+                        "subInfo": "",
+                        "gameDetailsHeader": {},
+                        "actions": [
+                            {
+                                "title": "Preview",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/atl-vs-det-0022501051/",
+                                    "resourceId": "0022501051",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Tickets",
+                                "resourceLocator": {
+                                    "resourceUrl": "https://a.data.nba.com/tickets/single/2025/0022501051/LEAG_GAMELINE",
+                                    "resourceId": "0022501051",
+                                    "resourceType": "game"
+                                }
+                            },
+                            {
+                                "title": "Game Charts",
+                                "resourceLocator": {
+                                    "resourceUrl": "/game/atl-vs-det-0022501051/game-charts",
+                                    "resourceId": "0022501051",
+                                    "resourceType": "game"
+                                }
+                            }
+                        ],
+                        "images": {
+                            "1920x1080": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/atl-det/1920x1080.png",
+                            "1280x720": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/atl-det/1280x720.png",
+                            "640x360": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/atl-det/640x360.png",
+                            "480x270": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/atl-det/480x270.png",
+                            "320x180": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/atl-det/320x180.png",
+                            "160x90": "https://cdn.nba.com/davinci/images/team-matchups/nba/latest/ced/atl-det/160x90.png"
+                        },
+                        "ifNecessary": false,
+                        "cardId": "",
+                        "contentAccess": {
+                            "isMemberGated": false,
+                            "isVivoContent": false,
+                            "cmsEntitlement": null,
+                            "isNikeGated": false
+                        },
+                        "shareUrl": "https://www.nba.com/game/atl-vs-det-0022501051",
+                        "ticketUrl": "https://a.data.nba.com/tickets/single/2025/0022501051/LEAG_GAMELINE",
+                        "isTntOT": false,
+                        "cardHat": null,
+                        "broadcasters": {
+                            "nationalBroadcasters": [
+                                {
+                                    "broadcasterId": 2,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "ESPN",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://espn.smart.link/b4uxwf8ow?ex_cid=NBA&gameId=401810906&referringapp=nba",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": "2",
+                                    "broadcasterLocalizationRegion": "",
+                                    "broadcasterLogoUrlDarkLg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/espn.png",
+                                    "broadcasterLogoUrlLightLg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/espn.png",
+                                    "broadcasterLogoUrlDarkSm": "https://cdn.nba.com/logos/nba/broadcast_logos/D/40h/espn.png",
+                                    "broadcasterLogoUrlLightSm": "https://cdn.nba.com/logos/nba/broadcast_logos/L/40h/espn.png",
+                                    "broadcasterLogoUrlLightSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/120h/espn.svg",
+                                    "broadcasterLogoUrlDarkSvg": "https://cdn.nba.com/logos/nba/broadcast_logos/D/120h/espn.svg",
+                                    "broadcasterLogoIcon1x1": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/espn.png",
+                                    "broadcasterLogoIcon1x1Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/square/espn.svg",
+                                    "broadcasterLogoIcon16x9": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/espn.png",
+                                    "broadcasterLogoIcon16x9Svg": "https://cdn.nba.com/logos/nba/broadcast_logos/L/dtc-icons/16x9/espn.svg"
+                                }
+                            ],
+                            "homeTvBroadcasters": [],
+                            "homeRadioBroadcasters": [],
+                            "awayTvBroadcasters": [],
+                            "awayRadioBroadcasters": [],
+                            "intlRadioBroadcasters": [],
+                            "intlTvBroadcasters": [],
+                            "homeOttBroadcasters": [],
+                            "awayOttBroadcasters": [],
+                            "intlOttBroadcasters": [],
+                            "nationalOttBroadcasters": [],
+                            "nationalRadioBroadcasters": [
+                                {
+                                    "broadcasterId": 3,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "ESPN Radio",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": ""
+                                },
+                                {
+                                    "broadcasterId": 1001098,
+                                    "broadcasterScope": null,
+                                    "broadcasterDisplayName": "SiriusXM",
+                                    "broadcasterLogoUrl": null,
+                                    "broadcasterVideoLink": "https://www.siriusxm.com/sports/nba",
+                                    "broadcasterDescription": "",
+                                    "broadcasterTeamId": null,
+                                    "broadcasterRanking": null,
+                                    "broadcasterLocalizationRegion": ""
+                                }
+                            ],
+                            "subscriptionBroadcasters": []
+                        },
+                        "showPostGameBroadcasters": false,
+                        "streamOrder": [
+                            {
+                                "rank": 0,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000445det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-ESPN",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-espn.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-espn.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-espn.png"
+                                },
+                                "title": "ESPN (In-Arena)",
+                                "description": "Follow in-arena action during halftime and game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-espn.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-espn.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 1,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000783det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-ESPN-Studio",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-espn-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-espn-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-espn-studio.png"
+                                },
+                                "title": "ESPN",
+                                "description": "Pre-game, halftime, and post game analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-espn-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-espn-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 2,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000456det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-DET",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "DET",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-det.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-det.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-det.png"
+                                },
+                                "title": "Pistons (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612765,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-det.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-det.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 3,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000448det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Team-ATL",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": "ATL",
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-team-atl.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-team-atl.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-team-atl.png"
+                                },
+                                "title": "Hawks (In-Arena)",
+                                "description": "Local broadcast with home arena game breaks",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": 1610612737,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-team-atl.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-team-atl.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 4,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000795det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-DET-Studio",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-det-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-det-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-det-studio.png"
+                                },
+                                "title": "Pistons (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-det-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-det-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 5,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000786det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-ATL-Studio",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-atl-studio.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-atl-studio.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-atl-studio.png"
+                                },
+                                "title": "Hawks (Studio Show)",
+                                "description": "Local broadcast with pre, post, and halftime analysis",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-atl-studio.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-atl-studio.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 6,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000440det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Spanish-ESPN",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-espn.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-spanish-espn.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-spanish-espn.png"
+                                },
+                                "title": "Spanish (ESPN)",
+                                "description": "ESPN Deportes",
+                                "categoryData": {
+                                    "categoryId": 44563,
+                                    "categoryName": "Languages",
+                                    "categoryRank": 4,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-spanish-espn.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-spanish-espn.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 7,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000436det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Portuguese-ESPN",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-portuguese-espn.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-portuguese-espn.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-portuguese-espn.png"
+                                },
+                                "title": "Portuguese",
+                                "description": "ESPN Deportes",
+                                "categoryData": {
+                                    "categoryId": 44563,
+                                    "categoryName": "Languages",
+                                    "categoryRank": 4,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-portuguese-espn.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-portuguese-espn.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 8,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000444det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Mobile-View",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-mobile-view.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-mobile-view.png"
+                                },
+                                "title": "Mobile View (In-Arena)",
+                                "description": "Optimized viewing experience, focused on close up action",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-mobile-view.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-mobile-view.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 9,
+                                "type": "production",
+                                "productionId": "g0022501051atl1001386det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-DR-ESPN",
+                                "status": "Init",
+                                "isRadio": false,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-espn.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-dr-espn.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-dr-espn.png"
+                                },
+                                "title": "ESPN (In Arena)",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44560,
+                                    "categoryName": "Broadcasts",
+                                    "categoryRank": 1,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-dr-espn.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-dr-espn.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 10,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000758det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-DET",
+                                "status": "Init",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-det.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-det.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-det.png"
+                                },
+                                "title": "Pistons Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-det.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-det.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            },
+                            {
+                                "rank": 11,
+                                "type": "production",
+                                "productionId": "g0022501051atl1000742det",
+                                "mediaKindVideoId": null,
+                                "uniqueName": "NSS-Radio-Team-ATL",
+                                "status": "Init",
+                                "isRadio": true,
+                                "inMarketTeamTricode": null,
+                                "logoMapping": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-atl.png",
+                                "logoMap": {
+                                    "logoMappingDark": "https://cdn.nba.com/logos/nba/streams/D/nss-radio-team-atl.png",
+                                    "logoMappingLight": "https://cdn.nba.com/logos/nba/streams/L/nss-radio-team-atl.png"
+                                },
+                                "title": "Hawks Radio",
+                                "description": "",
+                                "categoryData": {
+                                    "categoryId": 44596,
+                                    "categoryName": "Audio",
+                                    "categoryRank": 5,
+                                    "isFeatureCategory": false
+                                },
+                                "isLocalAccess": false,
+                                "teamId": null,
+                                "thumbnails": {
+                                    "thumbnailLarge": "https://cdn.nba.com/logos/nba/streams/T/large/nss-radio-team-atl.png",
+                                    "thumbnailSmall": "https://cdn.nba.com/logos/nba/streams/T/small/nss-radio-team-atl.png"
+                                },
+                                "featuredImage": null,
+                                "videoDuration": null,
+                                "videoFranchisesName": null
+                            }
+                        ],
+                        "extraMoreMenuItems": null,
+                        "gameSubtype": "",
+                        "isNeutral": false,
+                        "scoreStripHeader": {
+                            "scoreStripSpoilerHeader": "",
+                            "scoreStripNonSpoilerHeader": ""
+                        },
+                        "isTabletopGame": true,
+                        "actualStartTimeUTC": null,
+                        "actualEndTimeUTC": null,
+                        "gameDurationSeconds": null,
+                        "immersiveExperiences": null
+                    },
+                    "cardType": "game",
+                    "cardId": "d83325e7-3d25-1d59-7541-7a6543dbfefe"
+                },
+                {
+                    "cardData": {
+                        "heroConfiguration": {
                             "headline": "Nuggets @ Suns",
                             "subhead": "",
                             "image": {

--- a/backend/tests/fixtures/sample-nba-odds-today-response.json
+++ b/backend/tests/fixtures/sample-nba-odds-today-response.json
@@ -1,0 +1,6078 @@
+{
+  "games": [
+    {
+      "gameId": "0022501042",
+      "sr_id": "sr:match:62924975",
+      "srMatchId": "62924975",
+      "homeTeamId": "1610612741",
+      "awayTeamId": "1610612745",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "3.950",
+                  "opening_odds": "6.100",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.250",
+                  "opening_odds": "1.110",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "3.950",
+                  "opening_odds": "6.100",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.250",
+                  "opening_odds": "1.110",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "4.200",
+                  "opening_odds": "4.100",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.247",
+                  "opening_odds": "1.256",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "4.000",
+                  "opening_odds": "3.800",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.260",
+                  "opening_odds": "1.280",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.250",
+                  "opening_odds": "1.267",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "4.100",
+                  "opening_odds": "3.900",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "8.5",
+                  "opening_spread": 8.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-8.5",
+                  "opening_spread": -8.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.780",
+                  "opening_odds": "1.860",
+                  "odds_trend": "down",
+                  "spread": "9.5",
+                  "opening_spread": 11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.040",
+                  "opening_odds": "1.840",
+                  "odds_trend": "up",
+                  "spread": "-9.5",
+                  "opening_spread": -11.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.780",
+                  "opening_odds": "1.860",
+                  "odds_trend": "down",
+                  "spread": "9.5",
+                  "opening_spread": 11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.040",
+                  "opening_odds": "1.840",
+                  "odds_trend": "up",
+                  "spread": "-9.5",
+                  "opening_spread": -11.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.926",
+                  "odds_trend": "down",
+                  "spread": "9",
+                  "opening_spread": 9
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.893",
+                  "odds_trend": "up",
+                  "spread": "-9",
+                  "opening_spread": -9
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "9",
+                  "opening_spread": 9
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-9",
+                  "opening_spread": -9
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.588",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "11.5",
+                  "opening_spread": 8.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.400",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "-11.5",
+                  "opening_spread": -8.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501043",
+      "sr_id": "sr:match:62924885",
+      "srMatchId": "62924885",
+      "homeTeamId": "1610612762",
+      "awayTeamId": "1610612761",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "3.900",
+                  "opening_odds": "6.000",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.250",
+                  "opening_odds": "1.120",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "3.900",
+                  "opening_odds": "6.000",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.250",
+                  "opening_odds": "1.120",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "4.200",
+                  "opening_odds": "6.000",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.247",
+                  "opening_odds": "1.143",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "4.500",
+                  "opening_odds": "6.000",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.220",
+                  "opening_odds": "1.140",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.211",
+                  "opening_odds": "1.133",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "4.500",
+                  "opening_odds": "6.250",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "10.5",
+                  "opening_spread": 12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-10.5",
+                  "opening_spread": -12.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.940",
+                  "opening_odds": "1.770",
+                  "spread": "8.5",
+                  "opening_spread": 13.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.830",
+                  "opening_odds": "1.930",
+                  "spread": "-8.5",
+                  "opening_spread": -13.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.940",
+                  "opening_odds": "1.770",
+                  "spread": "8.5",
+                  "opening_spread": 13.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.830",
+                  "opening_odds": "1.930",
+                  "spread": "-8.5",
+                  "opening_spread": -13.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "spread": "10",
+                  "opening_spread": 13
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "spread": "-10",
+                  "opening_spread": -13
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "2.000",
+                  "odds_trend": "down",
+                  "spread": "9.5",
+                  "opening_spread": 11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.850",
+                  "opening_odds": "1.750",
+                  "odds_trend": "up",
+                  "spread": "-9.5",
+                  "opening_spread": -11.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.690",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "11.5",
+                  "opening_spread": 12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.180",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-11.5",
+                  "opening_spread": -12.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501044",
+      "sr_id": "sr:match:62924577",
+      "srMatchId": "62924577",
+      "homeTeamId": "1610612742",
+      "awayTeamId": "1610612744",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.150",
+                  "opening_odds": "2.200",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.700",
+                  "opening_odds": "1.650",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.150",
+                  "opening_odds": "2.200",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.700",
+                  "opening_odds": "1.650",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.120",
+                  "opening_odds": "2.240",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.758",
+                  "opening_odds": "1.685",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.150",
+                  "opening_odds": "2.150",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.730",
+                  "opening_odds": "1.730",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.741",
+                  "opening_odds": "1.741",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.100",
+                  "opening_odds": "2.100",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.950",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "1.5",
+                  "opening_spread": 1.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.850",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-1.5",
+                  "opening_spread": -1.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.930",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.830",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -2.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.930",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.830",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -2.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 3
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -3
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.750",
+                  "spread": "2",
+                  "opening_spread": 3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "2.000",
+                  "spread": "-2",
+                  "opening_spread": -3.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.267",
+                  "opening_odds": "1.980",
+                  "odds_trend": "down",
+                  "spread": "11.5",
+                  "opening_spread": 1.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "3.900",
+                  "opening_odds": "1.847",
+                  "odds_trend": "up",
+                  "spread": "-11.5",
+                  "opening_spread": -1.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501045",
+      "sr_id": "sr:match:62925335",
+      "srMatchId": "62925335",
+      "homeTeamId": "1610612757",
+      "awayTeamId": "1610612751",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.070",
+                  "opening_odds": "1.050",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "8.200",
+                  "opening_odds": "9.200",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.070",
+                  "opening_odds": "1.050",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "8.200",
+                  "opening_odds": "9.200",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.091",
+                  "opening_odds": "1.105",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "8.000",
+                  "opening_odds": "7.100",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.090",
+                  "opening_odds": "1.120",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "8.000",
+                  "opening_odds": "6.800",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "7.750",
+                  "opening_odds": "7.000",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.091",
+                  "opening_odds": "1.111",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-14.5",
+                  "opening_spread": -14.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "14.5",
+                  "opening_spread": 14.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.750",
+                  "opening_odds": "1.950",
+                  "odds_trend": "down",
+                  "spread": "-14.5",
+                  "opening_spread": -16.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.040",
+                  "opening_odds": "1.750",
+                  "odds_trend": "up",
+                  "spread": "14.5",
+                  "opening_spread": 16.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.750",
+                  "opening_odds": "1.950",
+                  "odds_trend": "down",
+                  "spread": "-14.5",
+                  "opening_spread": -16.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.040",
+                  "opening_odds": "1.750",
+                  "odds_trend": "up",
+                  "spread": "14.5",
+                  "opening_spread": 16.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.893",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "-15.5",
+                  "opening_spread": -13.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.926",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "15.5",
+                  "opening_spread": 13.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.800",
+                  "opening_odds": "1.750",
+                  "odds_trend": "down",
+                  "spread": "-14.5",
+                  "opening_spread": -12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.950",
+                  "opening_odds": "2.000",
+                  "odds_trend": "up",
+                  "spread": "14.5",
+                  "opening_spread": 12.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "-15.5",
+                  "opening_spread": -13.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "15.5",
+                  "opening_spread": 13.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501046",
+      "sr_id": "sr:match:62925513",
+      "srMatchId": "62925513",
+      "homeTeamId": "1610612746",
+      "awayTeamId": "1610612749",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.100",
+                  "opening_odds": "1.120",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "7.000",
+                  "opening_odds": "5.700",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.100",
+                  "opening_odds": "1.120",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "7.000",
+                  "opening_odds": "5.700",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.139",
+                  "opening_odds": "1.200",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.500",
+                  "opening_odds": "4.850",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.120",
+                  "opening_odds": "1.180",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "6.800",
+                  "opening_odds": "5.200",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "6.750",
+                  "opening_odds": "6.000",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.111",
+                  "opening_odds": "1.143",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "-12.5",
+                  "opening_spread": -12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "12.5",
+                  "opening_spread": 12.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.930",
+                  "opening_odds": "1.830",
+                  "odds_trend": "up",
+                  "spread": "-14.5",
+                  "opening_spread": -11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "14.5",
+                  "opening_spread": 11.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.930",
+                  "opening_odds": "1.830",
+                  "odds_trend": "up",
+                  "spread": "-14.5",
+                  "opening_spread": -11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "14.5",
+                  "opening_spread": 11.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "spread": "-14",
+                  "opening_spread": -11
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "spread": "14",
+                  "opening_spread": 11
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "2.000",
+                  "opening_odds": "2.000",
+                  "odds_trend": "up",
+                  "spread": "-14.5",
+                  "opening_spread": -12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.750",
+                  "opening_odds": "1.750",
+                  "odds_trend": "down",
+                  "spread": "14.5",
+                  "opening_spread": 12.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "2.150",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-15.5",
+                  "opening_spread": -11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.714",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "15.5",
+                  "opening_spread": 11.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501047",
+      "sr_id": "sr:match:62926105",
+      "srMatchId": "62926105",
+      "homeTeamId": "1610612766",
+      "awayTeamId": "1610612758",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.070",
+                  "opening_odds": "1.060",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "8.500",
+                  "opening_odds": "8.400",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.070",
+                  "opening_odds": "1.060",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "8.500",
+                  "opening_odds": "8.400",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.056",
+                  "opening_odds": "1.074",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "10.800",
+                  "opening_odds": "9.100",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.050",
+                  "opening_odds": "1.070",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "11.000",
+                  "opening_odds": "9.000",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "11.000",
+                  "opening_odds": "9.250",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.050",
+                  "opening_odds": "1.071",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "-16.5",
+                  "opening_spread": -17.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "16.5",
+                  "opening_spread": 17.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.920",
+                  "opening_odds": "1.920",
+                  "odds_trend": "down",
+                  "spread": "-18.5",
+                  "opening_spread": -17.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.850",
+                  "opening_odds": "1.780",
+                  "odds_trend": "up",
+                  "spread": "18.5",
+                  "opening_spread": 17.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.920",
+                  "opening_odds": "1.920",
+                  "odds_trend": "down",
+                  "spread": "-18.5",
+                  "opening_spread": -17.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.850",
+                  "opening_odds": "1.780",
+                  "odds_trend": "up",
+                  "spread": "18.5",
+                  "opening_spread": 17.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.926",
+                  "opening_odds": "1.893",
+                  "spread": "-18",
+                  "opening_spread": -16.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.893",
+                  "opening_odds": "1.926",
+                  "spread": "18",
+                  "opening_spread": 16.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.850",
+                  "opening_odds": "1.750",
+                  "odds_trend": "down",
+                  "spread": "-17.5",
+                  "opening_spread": -15.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "2.000",
+                  "odds_trend": "up",
+                  "spread": "17.5",
+                  "opening_spread": 15.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.870",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "-17.5",
+                  "opening_spread": -16.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.952",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "17.5",
+                  "opening_spread": 16.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501048",
+      "sr_id": "sr:match:62926349",
+      "srMatchId": "62926349",
+      "homeTeamId": "1610612752",
+      "awayTeamId": "1610612740",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.280",
+                  "opening_odds": "1.200",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "3.650",
+                  "opening_odds": "4.400",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.280",
+                  "opening_odds": "1.200",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "3.650",
+                  "opening_odds": "4.400",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.294",
+                  "opening_odds": "1.278",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "3.750",
+                  "opening_odds": "3.900",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.300",
+                  "opening_odds": "1.260",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "3.700",
+                  "opening_odds": "4.000",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "3.750",
+                  "opening_odds": "4.000",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.286",
+                  "opening_odds": "1.250",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-8.5",
+                  "opening_spread": -8.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "8.5",
+                  "opening_spread": 8.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.780",
+                  "odds_trend": "up",
+                  "spread": "-8.5",
+                  "opening_spread": -8.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.920",
+                  "odds_trend": "down",
+                  "spread": "8.5",
+                  "opening_spread": 8.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.780",
+                  "odds_trend": "up",
+                  "spread": "-8.5",
+                  "opening_spread": -8.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.920",
+                  "odds_trend": "down",
+                  "spread": "8.5",
+                  "opening_spread": 8.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-8.5",
+                  "opening_spread": -9
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "8.5",
+                  "opening_spread": 9
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.750",
+                  "opening_odds": "2.000",
+                  "odds_trend": "up",
+                  "spread": "-7.5",
+                  "opening_spread": -10.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.000",
+                  "opening_odds": "1.750",
+                  "odds_trend": "down",
+                  "spread": "7.5",
+                  "opening_spread": 10.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.980",
+                  "odds_trend": "up",
+                  "spread": "-8.5",
+                  "opening_spread": -9.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.847",
+                  "odds_trend": "down",
+                  "spread": "8.5",
+                  "opening_spread": 9.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501049",
+      "sr_id": "sr:match:62925729",
+      "srMatchId": "62925729",
+      "homeTeamId": "1610612739",
+      "awayTeamId": "1610612753",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.220",
+                  "opening_odds": "1.380",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "4.350",
+                  "opening_odds": "2.950",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.220",
+                  "opening_odds": "1.380",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "4.350",
+                  "opening_odds": "2.950",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.217",
+                  "opening_odds": "1.250",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "4.600",
+                  "opening_odds": "4.150",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.220",
+                  "opening_odds": "1.240",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "4.500",
+                  "opening_odds": "4.200",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "4.600",
+                  "opening_odds": "4.200",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.211",
+                  "opening_odds": "1.235",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-10.5",
+                  "opening_spread": -9.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "10.5",
+                  "opening_spread": 9.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.910",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "-10.5",
+                  "opening_spread": -6.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.890",
+                  "opening_odds": "1.830",
+                  "odds_trend": "down",
+                  "spread": "10.5",
+                  "opening_spread": 6.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.910",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "-10.5",
+                  "opening_spread": -6.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.890",
+                  "opening_odds": "1.830",
+                  "odds_trend": "down",
+                  "spread": "10.5",
+                  "opening_spread": 6.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.893",
+                  "opening_odds": "1.926",
+                  "odds_trend": "down",
+                  "spread": "-10.5",
+                  "opening_spread": -10
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.926",
+                  "opening_odds": "1.893",
+                  "odds_trend": "up",
+                  "spread": "10.5",
+                  "opening_spread": 10
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.750",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "-9.5",
+                  "opening_spread": -10
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.000",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "9.5",
+                  "opening_spread": 10
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "-10.5",
+                  "opening_spread": -10.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "10.5",
+                  "opening_spread": 10.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501050",
+      "sr_id": "sr:match:62924773",
+      "srMatchId": "62924773",
+      "homeTeamId": "1610612756",
+      "awayTeamId": "1610612743",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "3.050",
+                  "opening_odds": "2.800",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.380",
+                  "opening_odds": "1.410",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "3.050",
+                  "opening_odds": "2.800",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.380",
+                  "opening_odds": "1.410",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.980",
+                  "opening_odds": "2.900",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.417",
+                  "opening_odds": "1.435",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.900",
+                  "opening_odds": "2.700",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.440",
+                  "opening_odds": "1.480",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.426",
+                  "opening_odds": "1.455",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.950",
+                  "opening_odds": "2.800",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "5.5",
+                  "opening_spread": 4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-5.5",
+                  "opening_spread": -4.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.730",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "7.5",
+                  "opening_spread": 5.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.070",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "-7.5",
+                  "opening_spread": -5.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.730",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "7.5",
+                  "opening_spread": 5.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.070",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "-7.5",
+                  "opening_spread": -5.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "6",
+                  "opening_spread": 6
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-6",
+                  "opening_spread": -6
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.400",
+                  "opening_odds": "1.950",
+                  "odds_trend": "down",
+                  "spread": "11.5",
+                  "opening_spread": 4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.800",
+                  "opening_odds": "1.800",
+                  "odds_trend": "up",
+                  "spread": "-11.5",
+                  "opening_spread": -4.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.333",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "11.5",
+                  "opening_spread": 5.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "3.400",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "-11.5",
+                  "opening_spread": -5.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501052",
+      "sr_id": "sr:match:62924927",
+      "srMatchId": "62924927",
+      "homeTeamId": "1610612754",
+      "awayTeamId": "1610612747",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "4.850",
+                  "opening_odds": "6.100",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.180",
+                  "opening_odds": "1.110",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "4.850",
+                  "opening_odds": "6.100",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.180",
+                  "opening_odds": "1.110",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "5.400",
+                  "opening_odds": "5.500",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.169",
+                  "opening_odds": "1.167",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "5.000",
+                  "opening_odds": "5.500",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.190",
+                  "opening_odds": "1.160",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.167",
+                  "opening_odds": "1.143",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.250",
+                  "opening_odds": "6.000",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "10.5",
+                  "opening_spread": 10.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-10.5",
+                  "opening_spread": -10.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.940",
+                  "opening_odds": "1.770",
+                  "odds_trend": "up",
+                  "spread": "10.5",
+                  "opening_spread": 14.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.860",
+                  "opening_odds": "1.930",
+                  "odds_trend": "down",
+                  "spread": "-10.5",
+                  "opening_spread": -14.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.940",
+                  "opening_odds": "1.770",
+                  "odds_trend": "up",
+                  "spread": "10.5",
+                  "opening_spread": 14.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.860",
+                  "opening_odds": "1.930",
+                  "odds_trend": "down",
+                  "spread": "-10.5",
+                  "opening_spread": -14.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.926",
+                  "opening_odds": "1.926",
+                  "odds_trend": "up",
+                  "spread": "10.5",
+                  "opening_spread": 11
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.893",
+                  "opening_odds": "1.893",
+                  "odds_trend": "down",
+                  "spread": "-10.5",
+                  "opening_spread": -11
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "2.000",
+                  "opening_odds": "1.850",
+                  "odds_trend": "down",
+                  "spread": "9.5",
+                  "opening_spread": 12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.750",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "-9.5",
+                  "opening_spread": -12.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "10.5",
+                  "opening_spread": 11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-10.5",
+                  "opening_spread": -11.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501053",
+      "sr_id": "sr:match:62925381",
+      "srMatchId": "62925381",
+      "homeTeamId": "1610612755",
+      "awayTeamId": "1610612741",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.370",
+                  "opening_odds": "1.320",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "3.100",
+                  "opening_odds": "3.250",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.370",
+                  "opening_odds": "1.320",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "3.100",
+                  "opening_odds": "3.250",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.392",
+                  "opening_odds": "1.408",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "3.100",
+                  "opening_odds": "3.000",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.440",
+                  "opening_odds": "1.440",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.900",
+                  "opening_odds": "2.900",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.900",
+                  "opening_odds": "3.300",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.426",
+                  "opening_odds": "1.339",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-6.5",
+                  "opening_spread": -6.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "6.5",
+                  "opening_spread": 6.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.890",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "-6.5",
+                  "opening_spread": -7.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.910",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "6.5",
+                  "opening_spread": 7.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.890",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "-6.5",
+                  "opening_spread": -7.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.910",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "6.5",
+                  "opening_spread": 7.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.943",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-7.5",
+                  "opening_spread": -6.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.877",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "7.5",
+                  "opening_spread": 6.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "2.000",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-7.5",
+                  "opening_spread": -6
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.750",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "7.5",
+                  "opening_spread": 6
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.847",
+                  "odds_trend": "up",
+                  "spread": "-6.5",
+                  "opening_spread": -6.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.980",
+                  "odds_trend": "down",
+                  "spread": "6.5",
+                  "opening_spread": 6.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501051",
+      "sr_id": "sr:match:62925699",
+      "srMatchId": "62925699",
+      "homeTeamId": "1610612765",
+      "awayTeamId": "1610612737",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.690",
+                  "opening_odds": "1.540",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.200",
+                  "opening_odds": "2.400",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.690",
+                  "opening_odds": "1.540",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.200",
+                  "opening_odds": "2.400",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.658",
+                  "opening_odds": "1.633",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.280",
+                  "opening_odds": "2.340",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.670",
+                  "opening_odds": "1.670",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.250",
+                  "opening_odds": "2.250",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.250",
+                  "opening_odds": "2.180",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.667",
+                  "opening_odds": "1.690",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-2.5",
+                  "opening_spread": -2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "2.5",
+                  "opening_spread": 2.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.890",
+                  "opening_odds": "1.790",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.910",
+                  "opening_odds": "1.910",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 3.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.890",
+                  "opening_odds": "1.790",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.910",
+                  "opening_odds": "1.910",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 3.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.870",
+                  "opening_odds": "1.943",
+                  "spread": "-2.5",
+                  "opening_spread": -3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.952",
+                  "opening_odds": "1.877",
+                  "spread": "2.5",
+                  "opening_spread": 3.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "2.000",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "-3.5",
+                  "opening_spread": -3
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.750",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "3.5",
+                  "opening_spread": 3
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-2.5",
+                  "opening_spread": -2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "2.5",
+                  "opening_spread": 2.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501054",
+      "sr_id": "sr:match:62925147",
+      "srMatchId": "62925147",
+      "homeTeamId": "1610612738",
+      "awayTeamId": "1610612760",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.150",
+                  "opening_odds": "2.200",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.710",
+                  "opening_odds": "1.660",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.150",
+                  "opening_odds": "2.200",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.710",
+                  "opening_odds": "1.660",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.140",
+                  "opening_odds": "2.300",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.746",
+                  "opening_odds": "1.649",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.200",
+                  "opening_odds": "2.250",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.700",
+                  "opening_odds": "1.670",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.714",
+                  "opening_odds": "1.645",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.150",
+                  "opening_odds": "2.250",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "1.5",
+                  "opening_spread": 2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-1.5",
+                  "opening_spread": -2.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.880",
+                  "opening_odds": "1.890",
+                  "odds_trend": "down",
+                  "spread": "2.5",
+                  "opening_spread": 2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.920",
+                  "opening_odds": "1.810",
+                  "odds_trend": "up",
+                  "spread": "-2.5",
+                  "opening_spread": -2.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.880",
+                  "opening_odds": "1.890",
+                  "odds_trend": "down",
+                  "spread": "2.5",
+                  "opening_spread": 2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.920",
+                  "opening_odds": "1.810",
+                  "odds_trend": "up",
+                  "spread": "-2.5",
+                  "opening_spread": -2.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.943",
+                  "odds_trend": "down",
+                  "spread": "2",
+                  "opening_spread": 2
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.877",
+                  "odds_trend": "up",
+                  "spread": "-2",
+                  "opening_spread": -2
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.850",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 3
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -3
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.847",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "2.5",
+                  "opening_spread": 3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.980",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-2.5",
+                  "opening_spread": -3.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501055",
+      "sr_id": "sr:match:62925947",
+      "srMatchId": "62925947",
+      "homeTeamId": "1610612739",
+      "awayTeamId": "1610612748",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.740",
+                  "opening_odds": "1.480",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.150",
+                  "opening_odds": "2.600",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.740",
+                  "opening_odds": "1.480",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.150",
+                  "opening_odds": "2.600",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.685",
+                  "opening_odds": "1.595",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.240",
+                  "opening_odds": "2.420",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.700",
+                  "opening_odds": "1.620",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.200",
+                  "opening_odds": "2.350",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.250",
+                  "opening_odds": "2.350",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.667",
+                  "opening_odds": "1.606",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-3.5",
+                  "opening_spread": -3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "3.5",
+                  "opening_spread": 3.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.920",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -5.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.780",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 5.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.920",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -5.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.780",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 5.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.877",
+                  "opening_odds": "1.909",
+                  "spread": "-2.5",
+                  "opening_spread": -4
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.943",
+                  "opening_odds": "1.909",
+                  "spread": "2.5",
+                  "opening_spread": 4
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.950",
+                  "odds_trend": "up",
+                  "spread": "-2.5",
+                  "opening_spread": -4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.850",
+                  "opening_odds": "1.800",
+                  "odds_trend": "down",
+                  "spread": "2.5",
+                  "opening_spread": 4.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "-2.5",
+                  "opening_spread": -3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "2.5",
+                  "opening_spread": 3.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501056",
+      "sr_id": "sr:match:62925595",
+      "srMatchId": "62925595",
+      "homeTeamId": "1610612763",
+      "awayTeamId": "1610612759",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "8.700",
+                  "opening_odds": "8.100",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.060",
+                  "opening_odds": "1.060",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "8.700",
+                  "opening_odds": "8.100",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.060",
+                  "opening_odds": "1.060",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "9.700",
+                  "opening_odds": "7.400",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.067",
+                  "opening_odds": "1.105",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "9.000",
+                  "opening_odds": "8.000",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.070",
+                  "opening_odds": "1.090",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.063",
+                  "opening_odds": "1.083",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "9.750",
+                  "opening_odds": "8.250",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "16.5",
+                  "opening_spread": 16.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-16.5",
+                  "opening_spread": -16.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.920",
+                  "opening_odds": "1.760",
+                  "odds_trend": "up",
+                  "spread": "16.5",
+                  "opening_spread": 17.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.880",
+                  "opening_odds": "1.940",
+                  "odds_trend": "down",
+                  "spread": "-16.5",
+                  "opening_spread": -17.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.920",
+                  "opening_odds": "1.760",
+                  "odds_trend": "up",
+                  "spread": "16.5",
+                  "opening_spread": 17.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.880",
+                  "opening_odds": "1.940",
+                  "odds_trend": "down",
+                  "spread": "-16.5",
+                  "opening_spread": -17.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.926",
+                  "opening_odds": "1.926",
+                  "odds_trend": "up",
+                  "spread": "16.5",
+                  "opening_spread": 15
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.893",
+                  "opening_odds": "1.893",
+                  "odds_trend": "down",
+                  "spread": "-16.5",
+                  "opening_spread": -15
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "2.000",
+                  "odds_trend": "up",
+                  "spread": "16.5",
+                  "opening_spread": 14.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.850",
+                  "opening_odds": "1.750",
+                  "odds_trend": "down",
+                  "spread": "-16.5",
+                  "opening_spread": -14.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.870",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "17.5",
+                  "opening_spread": 15.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.952",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "-17.5",
+                  "opening_spread": -15.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501057",
+      "sr_id": "sr:match:62925153",
+      "srMatchId": "62925153",
+      "homeTeamId": "1610612762",
+      "awayTeamId": "1610612764",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.520",
+                  "opening_odds": "1.480",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.500",
+                  "opening_odds": "2.550",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.520",
+                  "opening_odds": "1.480",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.500",
+                  "opening_odds": "2.550",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.515",
+                  "opening_odds": "1.505",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.620",
+                  "opening_odds": "2.660",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.580",
+                  "opening_odds": "1.650",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.450",
+                  "opening_odds": "2.300",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.450",
+                  "opening_odds": "2.500",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.556",
+                  "opening_odds": "1.541",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-4.5",
+                  "opening_spread": -4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "4.5",
+                  "opening_spread": 4.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.880",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "-4.5",
+                  "opening_spread": -4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.880",
+                  "opening_odds": "1.880",
+                  "odds_trend": "down",
+                  "spread": "4.5",
+                  "opening_spread": 4.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.880",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "-4.5",
+                  "opening_spread": -4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.880",
+                  "opening_odds": "1.880",
+                  "odds_trend": "down",
+                  "spread": "4.5",
+                  "opening_spread": 4.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.877",
+                  "opening_odds": "1.909",
+                  "spread": "-4.5",
+                  "opening_spread": -5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.943",
+                  "opening_odds": "1.909",
+                  "spread": "4.5",
+                  "opening_spread": 5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-4",
+                  "opening_spread": -4
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "4",
+                  "opening_spread": 4
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.952",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-4.5",
+                  "opening_spread": -4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "4.5",
+                  "opening_spread": 4.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501058",
+      "sr_id": "sr:match:62924677",
+      "srMatchId": "62924677",
+      "homeTeamId": "1610612750",
+      "awayTeamId": "1610612745",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.010",
+                  "opening_odds": "1.940",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.800",
+                  "opening_odds": "1.830",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.010",
+                  "opening_odds": "1.940",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.800",
+                  "opening_odds": "1.830",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.080",
+                  "opening_odds": "2.000",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.794",
+                  "opening_odds": "1.847",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.050",
+                  "opening_odds": "1.920",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.800",
+                  "opening_odds": "1.920",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.769",
+                  "opening_odds": "1.833",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.050",
+                  "opening_odds": "2.000",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "1.5",
+                  "opening_spread": 1.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-1.5",
+                  "opening_spread": -1.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.920",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "1.5",
+                  "opening_spread": 1.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.880",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-1.5",
+                  "opening_spread": -1.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.920",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "1.5",
+                  "opening_spread": 1.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.880",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-1.5",
+                  "opening_spread": -1.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.926",
+                  "opening_odds": "1.926",
+                  "odds_trend": "up",
+                  "spread": "1.5",
+                  "opening_spread": 1
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.893",
+                  "opening_odds": "1.893",
+                  "odds_trend": "down",
+                  "spread": "-1.5",
+                  "opening_spread": -1
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "2.050",
+                  "odds_trend": "up",
+                  "spread": "1.5",
+                  "opening_spread": -2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.720",
+                  "odds_trend": "down",
+                  "spread": "-1.5",
+                  "opening_spread": 2.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "1.5",
+                  "opening_spread": 1.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "-1.5",
+                  "opening_spread": -1.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501060",
+      "sr_id": "sr:match:62925123",
+      "srMatchId": "62925123",
+      "homeTeamId": "1610612744",
+      "awayTeamId": "1610612751",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.150",
+                  "opening_odds": "1.220",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.450",
+                  "opening_odds": "4.100",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.150",
+                  "opening_odds": "1.220",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.450",
+                  "opening_odds": "4.100",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.161",
+                  "opening_odds": "1.179",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.600",
+                  "opening_odds": "5.200",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.160",
+                  "opening_odds": "1.190",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.500",
+                  "opening_odds": "5.000",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "5.500",
+                  "opening_odds": "5.250",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.160",
+                  "opening_odds": "1.167",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-11.5",
+                  "opening_spread": -11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "11.5",
+                  "opening_spread": 11.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.860",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "-11.5",
+                  "opening_spread": -9.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.940",
+                  "opening_odds": "1.880",
+                  "odds_trend": "down",
+                  "spread": "11.5",
+                  "opening_spread": 9.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.860",
+                  "opening_odds": "1.820",
+                  "odds_trend": "up",
+                  "spread": "-11.5",
+                  "opening_spread": -9.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.940",
+                  "opening_odds": "1.880",
+                  "odds_trend": "down",
+                  "spread": "11.5",
+                  "opening_spread": 9.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.943",
+                  "opening_odds": "1.909",
+                  "spread": "-12.5",
+                  "opening_spread": -11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.877",
+                  "opening_odds": "1.909",
+                  "spread": "12.5",
+                  "opening_spread": 11.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-12.5",
+                  "opening_spread": -11
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.850",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "12.5",
+                  "opening_spread": 11
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.952",
+                  "opening_odds": "1.847",
+                  "odds_trend": "down",
+                  "spread": "-12.5",
+                  "opening_spread": -10.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.980",
+                  "odds_trend": "up",
+                  "spread": "12.5",
+                  "opening_spread": 10.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501061",
+      "sr_id": "sr:match:62926095",
+      "srMatchId": "62926095",
+      "homeTeamId": "1610612757",
+      "awayTeamId": "1610612749",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.110",
+                  "opening_odds": "1.300",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "6.700",
+                  "opening_odds": "3.400",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.110",
+                  "opening_odds": "1.300",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "6.700",
+                  "opening_odds": "3.400",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.154",
+                  "opening_odds": "1.154",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.800",
+                  "opening_odds": "5.800",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.150",
+                  "opening_odds": "1.160",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.800",
+                  "opening_odds": "5.500",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "5.750",
+                  "opening_odds": "5.500",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.154",
+                  "opening_odds": "1.160",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-12.5",
+                  "opening_spread": -12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "12.5",
+                  "opening_spread": 12.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.880",
+                  "opening_odds": "1.790",
+                  "odds_trend": "up",
+                  "spread": "-12.5",
+                  "opening_spread": -7.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.920",
+                  "opening_odds": "1.910",
+                  "odds_trend": "down",
+                  "spread": "12.5",
+                  "opening_spread": 7.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.880",
+                  "opening_odds": "1.790",
+                  "odds_trend": "up",
+                  "spread": "-12.5",
+                  "opening_spread": -7.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.920",
+                  "opening_odds": "1.910",
+                  "odds_trend": "down",
+                  "spread": "12.5",
+                  "opening_spread": 7.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.893",
+                  "opening_odds": "1.893",
+                  "spread": "-12.5",
+                  "opening_spread": -12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.926",
+                  "opening_odds": "1.926",
+                  "spread": "12.5",
+                  "opening_spread": 12.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.950",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "-13.5",
+                  "opening_spread": -12
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.800",
+                  "opening_odds": "1.900",
+                  "odds_trend": "up",
+                  "spread": "13.5",
+                  "opening_spread": 12
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.952",
+                  "odds_trend": "down",
+                  "spread": "-12.5",
+                  "opening_spread": -12.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.870",
+                  "odds_trend": "up",
+                  "spread": "12.5",
+                  "opening_spread": 12.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501059",
+      "sr_id": "sr:match:62926319",
+      "srMatchId": "62926319",
+      "homeTeamId": "1610612743",
+      "awayTeamId": "1610612742",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.140",
+                  "opening_odds": "1.170",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.700",
+                  "opening_odds": "4.850",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.140",
+                  "opening_odds": "1.170",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.700",
+                  "opening_odds": "4.850",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.139",
+                  "opening_odds": "1.111",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "6.200",
+                  "opening_odds": "7.100",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.150",
+                  "opening_odds": "1.130",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "5.800",
+                  "opening_odds": "6.500",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "6.000",
+                  "opening_odds": "8.000",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.143",
+                  "opening_odds": "1.091",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-13.5",
+                  "opening_spread": -13.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "13.5",
+                  "opening_spread": 13.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.930",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "-12.5",
+                  "opening_spread": -11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.840",
+                  "odds_trend": "down",
+                  "spread": "12.5",
+                  "opening_spread": 11.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.930",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "-12.5",
+                  "opening_spread": -11.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.840",
+                  "odds_trend": "down",
+                  "spread": "12.5",
+                  "opening_spread": 11.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.943",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "-12.5",
+                  "opening_spread": -14.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.877",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "12.5",
+                  "opening_spread": 14.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.850",
+                  "opening_odds": "1.850",
+                  "odds_trend": "up",
+                  "spread": "-11.5",
+                  "opening_spread": -13.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "odds_trend": "down",
+                  "spread": "11.5",
+                  "opening_spread": 13.5
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.980",
+                  "opening_odds": "1.909",
+                  "odds_trend": "up",
+                  "spread": "-12.5",
+                  "opening_spread": -14.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.847",
+                  "opening_odds": "1.909",
+                  "odds_trend": "down",
+                  "spread": "12.5",
+                  "opening_spread": 14.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501062",
+      "sr_id": "sr:match:62925277",
+      "srMatchId": "62925277",
+      "homeTeamId": "1610612746",
+      "awayTeamId": "1610612761",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.530",
+                  "opening_odds": "1.680",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.500",
+                  "opening_odds": "2.150",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.530",
+                  "opening_odds": "1.680",
+                  "odds_trend": "up"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.500",
+                  "opening_odds": "2.150",
+                  "odds_trend": "down"
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.562",
+                  "opening_odds": "1.649",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.500",
+                  "opening_odds": "2.300",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "1.560",
+                  "opening_odds": "1.650",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "2.500",
+                  "opening_odds": "2.300",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "2.500",
+                  "opening_odds": "2.450",
+                  "odds_trend": "down"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.541",
+                  "opening_odds": "1.571",
+                  "odds_trend": "up"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:5277",
+              "name": "Mozzartbet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-4.5",
+                  "opening_spread": -4.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "4.5",
+                  "opening_spread": 4.5
+                }
+              ],
+              "url": "https://www.mozzartbet.com/sr/nba?utm_source=nba&utm_medium=mbet&utm_campaign=nba_match_schedule_mbet",
+              "countryCode": "RS"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.910",
+                  "opening_odds": "1.840",
+                  "odds_trend": "down",
+                  "spread": "-4.5",
+                  "opening_spread": -2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.890",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "4.5",
+                  "opening_spread": 2.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "GR"
+            },
+            {
+              "id": "sr:book:6565",
+              "name": "Novibet",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.910",
+                  "opening_odds": "1.840",
+                  "odds_trend": "down",
+                  "spread": "-4.5",
+                  "opening_spread": -2.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.890",
+                  "opening_odds": "1.860",
+                  "odds_trend": "up",
+                  "spread": "4.5",
+                  "opening_spread": 2.5
+                }
+              ],
+              "url": "https://www.novibet.gr/stoixima/mpasket/4372811/united-states/nba/5142827?btag=20045[â€¦]ce=2004578_&utm_medium=affiliate&utm_campaign=STOIXIMAGENERIC",
+              "countryCode": "CY"
+            },
+            {
+              "id": "sr:book:18186",
+              "name": "FanDuel",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.909",
+                  "opening_odds": "1.952",
+                  "odds_trend": "up",
+                  "spread": "-4",
+                  "opening_spread": -3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.909",
+                  "opening_odds": "1.870",
+                  "odds_trend": "down",
+                  "spread": "4",
+                  "opening_spread": 3.5
+                }
+              ],
+              "url": "https://servedby.flashtalking.com/click/8/270247;9354109;369307;211;0/?ft_width=1&ft_height=1&gdpr=${GDPR}&gdpr_consent=${GDPR_CONSENT_78}&us_privacy=${US_PRIVACY}&url=41387574",
+              "countryCode": "US"
+            },
+            {
+              "id": "sr:book:35226",
+              "name": "TabAustralia",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "-4",
+                  "opening_spread": -3
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.900",
+                  "opening_odds": "1.900",
+                  "spread": "4",
+                  "opening_spread": 3
+                }
+              ],
+              "url": "https://www.tab.com.au/sports/betting/Basketball/competitions/NBA",
+              "countryCode": "AU"
+            },
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.952",
+                  "opening_odds": "1.847",
+                  "odds_trend": "down",
+                  "spread": "-4.5",
+                  "opening_spread": -3.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "1.870",
+                  "opening_odds": "1.980",
+                  "odds_trend": "up",
+                  "spread": "4.5",
+                  "opening_spread": 3.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gameId": "0022501065",
+      "sr_id": "sr:match:62924911",
+      "srMatchId": "62924911",
+      "homeTeamId": "1610612753",
+      "awayTeamId": "1610612758",
+      "markets": [
+        {
+          "name": "2way",
+          "odds_type_id": 1,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 1,
+                  "type": "home",
+                  "odds": "9.250",
+                  "opening_odds": "9.250"
+                },
+                {
+                  "odds_field_id": 2,
+                  "type": "away",
+                  "odds": "1.071",
+                  "opening_odds": "1.071"
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        },
+        {
+          "name": "spread",
+          "odds_type_id": 4,
+          "group_name": "regular",
+          "books": [
+            {
+              "id": "sr:book:38812",
+              "name": "SportingbetBr",
+              "outcomes": [
+                {
+                  "odds_field_id": 10,
+                  "type": "home",
+                  "odds": "1.690",
+                  "opening_odds": "1.952",
+                  "spread": "-14.5",
+                  "opening_spread": -17.5
+                },
+                {
+                  "odds_field_id": 12,
+                  "type": "away",
+                  "odds": "2.180",
+                  "opening_odds": "1.870",
+                  "spread": "14.5",
+                  "opening_spread": 17.5
+                }
+              ],
+              "url": "https://sports.sportingbet.bet.br/?wm=5507762&utm_source=app-nba-voa&utm_campaign=linkdabioappnba2025&utm_content={{ad.id}}&utm_medium=appnba-{{campaign.id}}_{{adset.id}}_{{ad.id}}&utm_term=5507762-linkdabioappnba2025-sptbet-sprts-br-2025-1-2-pt-app--acq-app&tdpeh=fb-{{ad.id}}{{site_source_name}}{{placement}}",
+              "countryCode": "BR"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/tests/test_leaderboard_service.py
+++ b/backend/tests/test_leaderboard_service.py
@@ -1,4 +1,7 @@
+import json
 from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pandas as pd
@@ -8,6 +11,8 @@ from nba_wins_pool.services.leaderboard_service import LeaderboardService
 from nba_wins_pool.services.nba_data_service import NBAGameStatus
 from nba_wins_pool.services.pool_season_service import TeamRosterMappings
 from nba_wins_pool.types.season_str import SeasonStr
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 UNDRAFTED = "Undrafted"
 
@@ -315,7 +320,7 @@ def _make_today_games_service(game_df, teams_data):
             roster_names = sorted({r["roster_name"] for r in teams_data if r["roster_name"] != UNDRAFTED})
             return TeamRosterMappings(teams_df=df, roster_names=roster_names)
 
-    return LeaderboardService(
+    service = LeaderboardService(
         db_session=None,
         pool_repository=None,
         roster_repository=None,
@@ -325,6 +330,9 @@ def _make_today_games_service(game_df, teams_data):
         pool_season_service=FakePoolSeasonService(),
         auction_valuation_service=None,
     )
+    # Avoid live HTTP calls in tests that don't exercise odds logic
+    service._fetch_fanduel_moneyline_odds = lambda: {}
+    return service
 
 
 # ---------------------------------------------------------------------------
@@ -626,3 +634,289 @@ async def test_today_games_empty_when_no_games():
     result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
 
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_fanduel_moneyline_odds tests
+# ---------------------------------------------------------------------------
+
+
+def _make_bare_service() -> LeaderboardService:
+    """Minimal LeaderboardService instance for testing odds parsing."""
+    return LeaderboardService(
+        db_session=None,
+        pool_repository=None,
+        roster_repository=None,
+        roster_slot_repository=None,
+        team_repository=None,
+        nba_data_service=None,
+        pool_season_service=None,
+        auction_valuation_service=None,
+    )
+
+
+def _mock_requests_get(fixture_data: dict):
+    mock_response = MagicMock()
+    mock_response.json.return_value = fixture_data
+    mock_response.raise_for_status.return_value = None
+    return mock_response
+
+
+def test_fetch_fanduel_odds_parses_fixture():
+    """Vig-adjusted FanDuel probabilities are computed correctly from the fixture."""
+    fixture = json.loads((FIXTURES_DIR / "sample-nba-odds-today-response.json").read_text())
+    service = _make_bare_service()
+
+    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(fixture)):
+        result = service._fetch_fanduel_moneyline_odds()
+
+    # Game 0022501042: FanDuel home 4.200, away 1.247
+    assert "0022501042" in result
+    odds = result["0022501042"]
+    raw_home = 1 / 4.200
+    raw_away = 1 / 1.247
+    total = raw_home + raw_away
+    assert odds["home"] == pytest.approx(raw_home / total, rel=1e-6)
+    assert odds["away"] == pytest.approx(raw_away / total, rel=1e-6)
+    assert odds["home"] + odds["away"] == pytest.approx(1.0, rel=1e-6)
+
+
+def test_fetch_fanduel_odds_all_probabilities_sum_to_one():
+    """Every game returned sums to 1.0."""
+    fixture = json.loads((FIXTURES_DIR / "sample-nba-odds-today-response.json").read_text())
+    service = _make_bare_service()
+
+    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(fixture)):
+        result = service._fetch_fanduel_moneyline_odds()
+
+    assert len(result) > 0
+    for game_id, odds in result.items():
+        assert odds["home"] + odds["away"] == pytest.approx(1.0, rel=1e-6), f"game {game_id} does not sum to 1"
+
+
+def test_fetch_fanduel_odds_skips_game_without_fanduel():
+    """Games with no FanDuel book are excluded from results."""
+    data = {
+        "games": [
+            {
+                "gameId": "0022501099",
+                "markets": [
+                    {
+                        "name": "2way",
+                        "books": [
+                            {
+                                "name": "Novibet",
+                                "outcomes": [
+                                    {"type": "home", "odds": "2.000"},
+                                    {"type": "away", "odds": "2.000"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    service = _make_bare_service()
+
+    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(data)):
+        result = service._fetch_fanduel_moneyline_odds()
+
+    assert "0022501099" not in result
+
+
+def test_fetch_fanduel_odds_skips_game_without_2way_market():
+    """Games with only a spread market and no 2way market are excluded."""
+    data = {
+        "games": [
+            {
+                "gameId": "0022501099",
+                "markets": [
+                    {
+                        "name": "spread",
+                        "books": [
+                            {
+                                "name": "FanDuel",
+                                "outcomes": [
+                                    {"type": "home", "odds": "1.909", "spread": "-5.5"},
+                                    {"type": "away", "odds": "1.909", "spread": "5.5"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    service = _make_bare_service()
+
+    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(data)):
+        result = service._fetch_fanduel_moneyline_odds()
+
+    assert "0022501099" not in result
+
+
+def test_fetch_fanduel_odds_returns_empty_on_http_error():
+    """Network failures return an empty dict without raising."""
+    service = _make_bare_service()
+
+    with patch("nba_wins_pool.services.leaderboard_service.requests.get", side_effect=Exception("connection refused")):
+        result = service._fetch_fanduel_moneyline_odds()
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_today_games_includes_odds_for_pregame():
+    """Pregame games include vig-adjusted win percentages from FanDuel."""
+    rows = [
+        {
+            "date_time": pd.Timestamp("2026-03-25T23:00:00Z", tz="UTC"),
+            "game_id": "0022501042",
+            "game_url": None,
+            "home_team": 1610612741,
+            "home_tricode": "CHI",
+            "home_score": None,
+            "away_team": 1610612745,
+            "away_tricode": "HOU",
+            "away_score": None,
+            "status": NBAGameStatus.PREGAME,
+            "status_text": "7:30 pm ET",
+            "game_clock": "",
+        }
+    ]
+    game_df = pd.DataFrame(rows)
+    game_df["date_time"] = pd.to_datetime(game_df["date_time"], utc=True).dt.tz_convert("US/Eastern")
+    game_df["winning_team"] = None
+    game_df["losing_team"] = None
+
+    teams_data = [
+        {
+            "team_external_id": 1610612741,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Bulls",
+            "abbreviation": "CHI",
+        },
+        {
+            "team_external_id": 1610612745,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Rockets",
+            "abbreviation": "HOU",
+        },
+    ]
+    service = _make_today_games_service(game_df, teams_data)
+
+    fixed_odds = {"0022501042": {"home": 0.2289, "away": 0.7711}}
+    service._fetch_fanduel_moneyline_odds = lambda: fixed_odds
+
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert len(result) == 1
+    game = result[0]
+    assert game["home_win_pct"] == pytest.approx(0.2289)
+    assert game["away_win_pct"] == pytest.approx(0.7711)
+
+
+@pytest.mark.asyncio
+async def test_today_games_odds_null_when_fanduel_unavailable():
+    """home_win_pct and away_win_pct are None when FanDuel odds are unavailable."""
+    rows = [
+        {
+            "date_time": pd.Timestamp("2026-03-25T23:00:00Z", tz="UTC"),
+            "game_id": "0022501042",
+            "game_url": None,
+            "home_team": 1610612741,
+            "home_tricode": "CHI",
+            "home_score": None,
+            "away_team": 1610612745,
+            "away_tricode": "HOU",
+            "away_score": None,
+            "status": NBAGameStatus.PREGAME,
+            "status_text": "7:30 pm ET",
+            "game_clock": "",
+        }
+    ]
+    game_df = pd.DataFrame(rows)
+    game_df["date_time"] = pd.to_datetime(game_df["date_time"], utc=True).dt.tz_convert("US/Eastern")
+    game_df["winning_team"] = None
+    game_df["losing_team"] = None
+
+    teams_data = [
+        {
+            "team_external_id": 1610612741,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Bulls",
+            "abbreviation": "CHI",
+        },
+        {
+            "team_external_id": 1610612745,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Rockets",
+            "abbreviation": "HOU",
+        },
+    ]
+    service = _make_today_games_service(game_df, teams_data)
+    service._fetch_fanduel_moneyline_odds = lambda: {}
+
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert result[0]["home_win_pct"] is None
+    assert result[0]["away_win_pct"] is None
+
+
+@pytest.mark.asyncio
+async def test_today_games_game_time_is_utc_string():
+    """game_time is serialized as a UTC ISO string regardless of the stored US/Eastern timezone."""
+    # 7:30 PM ET on 2026-03-25 = 23:30 UTC
+    rows = [
+        {
+            "date_time": pd.Timestamp("2026-03-25T23:30:00Z", tz="UTC"),
+            "game_id": "0022501042",
+            "game_url": None,
+            "home_team": 1610612741,
+            "home_tricode": "CHI",
+            "home_score": None,
+            "away_team": 1610612745,
+            "away_tricode": "HOU",
+            "away_score": None,
+            "status": NBAGameStatus.PREGAME,
+            "status_text": "7:30 pm ET",
+            "game_clock": "",
+        }
+    ]
+    game_df = pd.DataFrame(rows)
+    game_df["date_time"] = pd.to_datetime(game_df["date_time"], utc=True).dt.tz_convert("US/Eastern")
+    game_df["winning_team"] = None
+    game_df["losing_team"] = None
+
+    teams_data = [
+        {
+            "team_external_id": 1610612741,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Bulls",
+            "abbreviation": "CHI",
+        },
+        {
+            "team_external_id": 1610612745,
+            "roster_name": UNDRAFTED,
+            "auction_price": None,
+            "logo_url": "",
+            "team_name": "Rockets",
+            "abbreviation": "HOU",
+        },
+    ]
+    service = _make_today_games_service(game_df, teams_data)
+
+    result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
+
+    assert result[0]["game_time"] == "2026-03-25T23:30:00"

--- a/backend/tests/test_leaderboard_service.py
+++ b/backend/tests/test_leaderboard_service.py
@@ -1,7 +1,4 @@
-import json
 from datetime import date
-from pathlib import Path
-from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pandas as pd
@@ -11,8 +8,6 @@ from nba_wins_pool.services.leaderboard_service import LeaderboardService
 from nba_wins_pool.services.nba_data_service import NBAGameStatus
 from nba_wins_pool.services.pool_season_service import TeamRosterMappings
 from nba_wins_pool.types.season_str import SeasonStr
-
-FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 UNDRAFTED = "Undrafted"
 
@@ -331,7 +326,7 @@ def _make_today_games_service(game_df, teams_data):
         auction_valuation_service=None,
     )
     # Avoid live HTTP calls in tests that don't exercise odds logic
-    service._fetch_fanduel_moneyline_odds = lambda: {}
+    service.nba_data_service.get_fanduel_moneyline_odds = lambda: {}
     return service
 
 
@@ -636,136 +631,6 @@ async def test_today_games_empty_when_no_games():
     assert result == []
 
 
-# ---------------------------------------------------------------------------
-# _fetch_fanduel_moneyline_odds tests
-# ---------------------------------------------------------------------------
-
-
-def _make_bare_service() -> LeaderboardService:
-    """Minimal LeaderboardService instance for testing odds parsing."""
-    return LeaderboardService(
-        db_session=None,
-        pool_repository=None,
-        roster_repository=None,
-        roster_slot_repository=None,
-        team_repository=None,
-        nba_data_service=None,
-        pool_season_service=None,
-        auction_valuation_service=None,
-    )
-
-
-def _mock_requests_get(fixture_data: dict):
-    mock_response = MagicMock()
-    mock_response.json.return_value = fixture_data
-    mock_response.raise_for_status.return_value = None
-    return mock_response
-
-
-def test_fetch_fanduel_odds_parses_fixture():
-    """Vig-adjusted FanDuel probabilities are computed correctly from the fixture."""
-    fixture = json.loads((FIXTURES_DIR / "sample-nba-odds-today-response.json").read_text())
-    service = _make_bare_service()
-
-    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(fixture)):
-        result = service._fetch_fanduel_moneyline_odds()
-
-    # Game 0022501042: FanDuel home 4.200, away 1.247
-    assert "0022501042" in result
-    odds = result["0022501042"]
-    raw_home = 1 / 4.200
-    raw_away = 1 / 1.247
-    total = raw_home + raw_away
-    assert odds["home"] == pytest.approx(raw_home / total, rel=1e-6)
-    assert odds["away"] == pytest.approx(raw_away / total, rel=1e-6)
-    assert odds["home"] + odds["away"] == pytest.approx(1.0, rel=1e-6)
-
-
-def test_fetch_fanduel_odds_all_probabilities_sum_to_one():
-    """Every game returned sums to 1.0."""
-    fixture = json.loads((FIXTURES_DIR / "sample-nba-odds-today-response.json").read_text())
-    service = _make_bare_service()
-
-    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(fixture)):
-        result = service._fetch_fanduel_moneyline_odds()
-
-    assert len(result) > 0
-    for game_id, odds in result.items():
-        assert odds["home"] + odds["away"] == pytest.approx(1.0, rel=1e-6), f"game {game_id} does not sum to 1"
-
-
-def test_fetch_fanduel_odds_skips_game_without_fanduel():
-    """Games with no FanDuel book are excluded from results."""
-    data = {
-        "games": [
-            {
-                "gameId": "0022501099",
-                "markets": [
-                    {
-                        "name": "2way",
-                        "books": [
-                            {
-                                "name": "Novibet",
-                                "outcomes": [
-                                    {"type": "home", "odds": "2.000"},
-                                    {"type": "away", "odds": "2.000"},
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            }
-        ]
-    }
-    service = _make_bare_service()
-
-    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(data)):
-        result = service._fetch_fanduel_moneyline_odds()
-
-    assert "0022501099" not in result
-
-
-def test_fetch_fanduel_odds_skips_game_without_2way_market():
-    """Games with only a spread market and no 2way market are excluded."""
-    data = {
-        "games": [
-            {
-                "gameId": "0022501099",
-                "markets": [
-                    {
-                        "name": "spread",
-                        "books": [
-                            {
-                                "name": "FanDuel",
-                                "outcomes": [
-                                    {"type": "home", "odds": "1.909", "spread": "-5.5"},
-                                    {"type": "away", "odds": "1.909", "spread": "5.5"},
-                                ],
-                            }
-                        ],
-                    }
-                ],
-            }
-        ]
-    }
-    service = _make_bare_service()
-
-    with patch("nba_wins_pool.services.leaderboard_service.requests.get", return_value=_mock_requests_get(data)):
-        result = service._fetch_fanduel_moneyline_odds()
-
-    assert "0022501099" not in result
-
-
-def test_fetch_fanduel_odds_returns_empty_on_http_error():
-    """Network failures return an empty dict without raising."""
-    service = _make_bare_service()
-
-    with patch("nba_wins_pool.services.leaderboard_service.requests.get", side_effect=Exception("connection refused")):
-        result = service._fetch_fanduel_moneyline_odds()
-
-    assert result == {}
-
-
 @pytest.mark.asyncio
 async def test_today_games_includes_odds_for_pregame():
     """Pregame games include vig-adjusted win percentages from FanDuel."""
@@ -811,7 +676,7 @@ async def test_today_games_includes_odds_for_pregame():
     service = _make_today_games_service(game_df, teams_data)
 
     fixed_odds = {"0022501042": {"home": 0.2289, "away": 0.7711}}
-    service._fetch_fanduel_moneyline_odds = lambda: fixed_odds
+    service.nba_data_service.get_fanduel_moneyline_odds = lambda: fixed_odds
 
     result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
 
@@ -864,7 +729,7 @@ async def test_today_games_odds_null_when_fanduel_unavailable():
         },
     ]
     service = _make_today_games_service(game_df, teams_data)
-    service._fetch_fanduel_moneyline_odds = lambda: {}
+    service.nba_data_service.get_fanduel_moneyline_odds = lambda: {}
 
     result = await service.get_today_games(uuid4(), SeasonStr("2025-26"))
 

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -3,7 +3,7 @@
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -694,3 +694,110 @@ class TestGameDateParsing:
             result = await nba_service.get_game_data(season)
 
         assert "future_game" not in result["game_id"].values
+
+
+def _mock_requests_get(fixture_data: dict):
+    mock_response = MagicMock()
+    mock_response.json.return_value = fixture_data
+    mock_response.raise_for_status.return_value = None
+    return mock_response
+
+
+class TestGetFanDuelMoneylineOdds:
+    """Tests for NbaDataService.get_fanduel_moneyline_odds."""
+
+    def test_parses_fixture(self, nba_service):
+        """Vig-adjusted probabilities are computed correctly from the fixture."""
+        fixture = json.loads((FIXTURES_DIR / "sample-nba-odds-today-response.json").read_text())
+
+        with patch("nba_wins_pool.services.nba_data_service.requests.get", return_value=_mock_requests_get(fixture)):
+            result = nba_service.get_fanduel_moneyline_odds()
+
+        # Game 0022501042: FanDuel home 4.200, away 1.247
+        assert "0022501042" in result
+        odds = result["0022501042"]
+        raw_home = 1 / 4.200
+        raw_away = 1 / 1.247
+        total = raw_home + raw_away
+        assert odds["home"] == pytest.approx(raw_home / total, rel=1e-6)
+        assert odds["away"] == pytest.approx(raw_away / total, rel=1e-6)
+        assert odds["home"] + odds["away"] == pytest.approx(1.0, rel=1e-6)
+
+    def test_all_probabilities_sum_to_one(self, nba_service):
+        """Every game in the fixture sums to 1.0."""
+        fixture = json.loads((FIXTURES_DIR / "sample-nba-odds-today-response.json").read_text())
+
+        with patch("nba_wins_pool.services.nba_data_service.requests.get", return_value=_mock_requests_get(fixture)):
+            result = nba_service.get_fanduel_moneyline_odds()
+
+        assert len(result) > 0
+        for game_id, odds in result.items():
+            assert odds["home"] + odds["away"] == pytest.approx(1.0, rel=1e-6), f"game {game_id} does not sum to 1"
+
+    def test_skips_game_without_fanduel(self, nba_service):
+        """Games with no FanDuel book are excluded from results."""
+        data = {
+            "games": [
+                {
+                    "gameId": "0022501099",
+                    "markets": [
+                        {
+                            "name": "2way",
+                            "books": [
+                                {
+                                    "name": "Novibet",
+                                    "outcomes": [
+                                        {"type": "home", "odds": "2.000"},
+                                        {"type": "away", "odds": "2.000"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with patch("nba_wins_pool.services.nba_data_service.requests.get", return_value=_mock_requests_get(data)):
+            result = nba_service.get_fanduel_moneyline_odds()
+
+        assert "0022501099" not in result
+
+    def test_skips_game_without_2way_market(self, nba_service):
+        """Games with only a spread market are excluded."""
+        data = {
+            "games": [
+                {
+                    "gameId": "0022501099",
+                    "markets": [
+                        {
+                            "name": "spread",
+                            "books": [
+                                {
+                                    "name": "FanDuel",
+                                    "outcomes": [
+                                        {"type": "home", "odds": "1.909", "spread": "-5.5"},
+                                        {"type": "away", "odds": "1.909", "spread": "5.5"},
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        with patch("nba_wins_pool.services.nba_data_service.requests.get", return_value=_mock_requests_get(data)):
+            result = nba_service.get_fanduel_moneyline_odds()
+
+        assert "0022501099" not in result
+
+    def test_returns_empty_on_http_error(self, nba_service):
+        """Network failures return an empty dict without raising."""
+        with patch(
+            "nba_wins_pool.services.nba_data_service.requests.get",
+            side_effect=Exception("connection refused"),
+        ):
+            result = nba_service.get_fanduel_moneyline_odds()
+
+        assert result == {}

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -92,10 +92,10 @@ class TestGetGameData:
 
     @pytest.mark.asyncio
     async def test_get_game_data_current_season_combines_live_and_schedule(self, nba_service, mock_repo):
-        """Test that get_game_data for current season combines gamecardfeed and CDN schedule."""
-        # Arrange
+        """Schedule supplies all games; gamecardfeed overlays live fields for today's games."""
         season = nba_service.get_current_season()
 
+        # today_game appears in both feeds; hist_game only in the schedule
         gamecardfeed_raw = {
             "modules": [
                 {
@@ -103,12 +103,13 @@ class TestGetGameData:
                         {
                             "cardType": "game",
                             "cardData": {
-                                "gameId": "live_001",
-                                "homeTeam": {"teamId": 1610612747, "score": 110, "teamTricode": "LAL"},
-                                "awayTeam": {"teamId": 1610612738, "score": 105, "teamTricode": "BOS"},
-                                "gameStatus": 3,
+                                "gameId": "today_game",
+                                "homeTeam": {"teamId": 1610612747, "score": 72, "teamTricode": "LAL"},
+                                "awayTeam": {"teamId": 1610612738, "score": 68, "teamTricode": "BOS"},
+                                "gameStatus": 2,  # INGAME
                                 "gameTimeUtc": "2024-10-22T23:30:00Z",
-                                "gameStatusText": "Final",
+                                "gameStatusText": "Q3 5:00",
+                                "gameClock": "PT05M00.00S",
                             },
                         }
                     ]
@@ -121,10 +122,10 @@ class TestGetGameData:
                 "seasonYear": season,
                 "gameDates": [
                     {
-                        "gameDate": "2024-10-15",
+                        "gameDate": "10/15/2024 00:00:00",
                         "games": [
                             {
-                                "gameId": "sched_001",
+                                "gameId": "hist_game",
                                 "gameStatus": 3,
                                 "gameDateTimeUTC": "2024-10-15T23:00:00Z",
                                 "homeTeam": {"teamId": 1610612747, "teamTricode": "LAL", "score": 120},
@@ -132,22 +133,42 @@ class TestGetGameData:
                                 "gameStatusText": "Final",
                                 "gameLabel": "",
                                 "seriesText": "",
+                                "arenaName": "Crypto.com Arena",
+                                "arenaCity": "Los Angeles",
+                                "arenaState": "CA",
                             }
                         ],
-                    }
+                    },
+                    {
+                        "gameDate": "10/22/2024 00:00:00",
+                        "games": [
+                            {
+                                "gameId": "today_game",
+                                "gameStatus": 1,
+                                "gameDateTimeUTC": "2024-10-22T23:30:00Z",
+                                "homeTeam": {"teamId": 1610612747, "teamTricode": "LAL", "score": 0},
+                                "awayTeam": {"teamId": 1610612738, "teamTricode": "BOS", "score": 0},
+                                "gameStatusText": "7:30 pm ET",
+                                "gameLabel": "",
+                                "seriesText": "",
+                                "arenaName": "Crypto.com Arena",
+                                "arenaCity": "Los Angeles",
+                                "arenaState": "CA",
+                            }
+                        ],
+                    },
                 ],
             }
         }
 
         with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
-            # Act
             result = await nba_service.get_game_data(season)
 
-            # Assert
-            assert isinstance(result, pd.DataFrame)
-            assert len(result) == 2  # Both live and schedule games
-            assert "winning_team" in result.columns
-            assert "losing_team" in result.columns
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+        assert set(result["game_id"]) == {"hist_game", "today_game"}
+        assert "winning_team" in result.columns
+        assert "losing_team" in result.columns
 
     @pytest.mark.asyncio
     async def test_get_game_data_historical_season_uses_cache(self, nba_service, mock_repo):
@@ -305,23 +326,23 @@ class TestParseGamecardfeed:
     def test_parses_all_games(self, nba_service, gamecardfeed_fixture):
         games, game_ids, scoreboard_date = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
 
-        assert len(games) == 4
-        assert len(game_ids) == 4
+        assert len(games) == 5
+        assert len(game_ids) == 5
 
     def test_game_ids(self, nba_service, gamecardfeed_fixture):
         games, game_ids, _ = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
 
-        expected_ids = {"0022501050", "0022501047", "0022501048", "0022501049"}
+        expected_ids = {"0022501050", "0022501047", "0022501048", "0022501049", "0022501051"}
         assert game_ids == expected_ids
         assert {g["game_id"] for g in games} == expected_ids
 
     def test_scoreboard_date(self, nba_service, gamecardfeed_fixture):
         _, _, scoreboard_date = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
 
-        # Games are at 2026-03-25 UTC, which is 2026-03-24 US/Eastern
+        # First game in fixture is 0022501051 at 2026-03-25T23:00:00Z = 2026-03-25 US/Eastern
         from datetime import date
 
-        assert scoreboard_date == date(2026, 3, 24)
+        assert scoreboard_date == date(2026, 3, 25)
 
     def test_game_statuses(self, nba_service, gamecardfeed_fixture):
         games, _, _ = nba_service._parse_gamecardfeed(gamecardfeed_fixture)
@@ -369,3 +390,307 @@ class TestParseGamecardfeed:
         assert "game_url" in result.columns
         den_phx = result[result["game_id"] == "0022501050"].iloc[0]
         assert den_phx["game_url"] == "https://www.nba.com/game/den-vs-phx-0022501050"
+
+
+def _make_schedule_raw(season: str, game_date: str, games: list[dict]) -> dict:
+    """Helper to build a minimal CDN schedule response."""
+    return {
+        "leagueSchedule": {
+            "seasonYear": season,
+            "gameDates": [{"gameDate": game_date, "games": games}],
+        }
+    }
+
+
+def _make_schedule_game(game_id: str, timestamp: str, **kwargs) -> dict:
+    """Helper to build a minimal schedule game entry."""
+    return {
+        "gameId": game_id,
+        "gameStatus": 1,
+        "gameDateTimeUTC": timestamp,
+        "homeTeam": {"teamId": 1, "teamTricode": "HOM", "score": 0},
+        "awayTeam": {"teamId": 2, "teamTricode": "AWY", "score": 0},
+        "gameStatusText": "7:30 pm ET",
+        "gameLabel": "",
+        "seriesText": "",
+        **kwargs,
+    }
+
+
+def _make_gamecardfeed_raw(game_id: str, timestamp: str, **kwargs) -> dict:
+    """Helper to build a minimal gamecardfeed response with one game."""
+    return {
+        "modules": [
+            {
+                "cards": [
+                    {
+                        "cardType": "game",
+                        "cardData": {
+                            "gameId": game_id,
+                            "gameTimeUtc": timestamp,
+                            "gameStatus": 2,
+                            "gameStatusText": "Q2 3:00",
+                            "gameClock": "PT03M00.00S",
+                            "homeTeam": {"teamId": 1, "score": 55, "teamTricode": "HOM"},
+                            "awayTeam": {"teamId": 2, "score": 50, "teamTricode": "AWY"},
+                            **kwargs,
+                        },
+                    }
+                ]
+            }
+        ]
+    }
+
+
+class TestGameUrl:
+    """game_url is populated from shareUrl (gamecardfeed) or constructed from teamSlugs (schedule)."""
+
+    def test_share_url_used_when_present(self, nba_service):
+        game = {
+            "gameId": "0022501042",
+            "gameStatus": 1,
+            "homeTeam": {"teamId": 1, "teamTricode": "DET", "teamSlug": "pistons", "score": 0},
+            "awayTeam": {"teamId": 2, "teamTricode": "ATL", "teamSlug": "hawks", "score": 0},
+            "gameStatusText": "7:00 pm ET",
+            "shareUrl": "https://www.nba.com/game/atl-vs-det-0022501042",
+        }
+        result = nba_service._parse_game_data(game, "2026-03-25T23:00:00Z")
+
+        assert result["game_url"] == "https://www.nba.com/game/atl-vs-det-0022501042"
+
+    def test_url_constructed_from_slugs_when_no_share_url(self, nba_service):
+        game = {
+            "gameId": "0022501051",
+            "gameStatus": 1,
+            "homeTeam": {"teamId": 1610612765, "teamTricode": "DET", "teamSlug": "pistons", "score": 0},
+            "awayTeam": {"teamId": 1610612737, "teamTricode": "ATL", "teamSlug": "hawks", "score": 0},
+            "gameStatusText": "7:00 pm ET",
+        }
+        result = nba_service._parse_game_data(game, "2026-03-25T23:00:00Z")
+
+        assert result["game_url"] == "https://www.nba.com/game/hawks-vs-pistons-0022501051"
+
+    @pytest.mark.asyncio
+    async def test_gamecardfeed_share_url_overrides_schedule_null(self, nba_service):
+        """shareUrl from gamecardfeed overlays the schedule's null game_url for today's games."""
+        season = nba_service.get_current_season()
+        timestamp = "2026-03-25T23:00:00Z"
+        gamecardfeed_raw = {
+            "modules": [
+                {
+                    "cards": [
+                        {
+                            "cardType": "game",
+                            "cardData": {
+                                "gameId": "0022501051",
+                                "gameTimeUtc": timestamp,
+                                "gameStatus": 1,
+                                "gameStatusText": "7:00 pm ET",
+                                "homeTeam": {"teamId": 1, "score": 0, "teamTricode": "DET"},
+                                "awayTeam": {"teamId": 2, "score": 0, "teamTricode": "ATL"},
+                                "shareUrl": "https://www.nba.com/game/atl-vs-det-0022501051",
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+        # Schedule entry has no shareUrl → game_url will be None or slug-constructed
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "03/25/2026 00:00:00",
+            [_make_schedule_game("0022501051", timestamp)],  # no shareUrl, no slugs
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        row = result[result["game_id"] == "0022501051"].iloc[0]
+        assert row["game_url"] == "https://www.nba.com/game/atl-vs-det-0022501051"
+
+    def test_url_none_when_no_share_url_and_no_slugs(self, nba_service):
+        game = {
+            "gameId": "0022501051",
+            "gameStatus": 1,
+            "homeTeam": {"teamId": 1, "teamTricode": "DET", "score": 0},
+            "awayTeam": {"teamId": 2, "teamTricode": "ATL", "score": 0},
+            "gameStatusText": "7:00 pm ET",
+        }
+        result = nba_service._parse_game_data(game, "2026-03-25T23:00:00Z")
+
+        assert result["game_url"] is None
+
+
+class TestArenaFields:
+    """Arena name/city/state are parsed from schedule and flow through to game data."""
+
+    def test_parse_game_data_extracts_arena_fields(self, nba_service):
+        game = {
+            "gameId": "0022501042",
+            "gameStatus": 1,
+            "homeTeam": {"teamId": 1, "teamTricode": "HOM", "score": 0},
+            "awayTeam": {"teamId": 2, "teamTricode": "AWY", "score": 0},
+            "gameStatusText": "7:30 pm ET",
+            "arenaName": "Little Caesars Arena",
+            "arenaCity": "Detroit",
+            "arenaState": "MI",
+        }
+        result = nba_service._parse_game_data(game, "2026-03-25T23:00:00Z")
+
+        assert result["arena_name"] == "Little Caesars Arena"
+        assert result["arena_city"] == "Detroit"
+        assert result["arena_state"] == "MI"
+
+    def test_parse_game_data_arena_fields_none_when_absent(self, nba_service):
+        game = {
+            "gameId": "0022501042",
+            "gameStatus": 1,
+            "homeTeam": {"teamId": 1, "teamTricode": "HOM", "score": 0},
+            "awayTeam": {"teamId": 2, "teamTricode": "AWY", "score": 0},
+            "gameStatusText": "7:30 pm ET",
+        }
+        result = nba_service._parse_game_data(game, "2026-03-25T23:00:00Z")
+
+        assert result["arena_name"] is None
+        assert result["arena_city"] is None
+        assert result["arena_state"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_game_data_arena_fields_from_schedule(self, nba_service):
+        """Arena fields come from the schedule and are present in the merged DataFrame."""
+        season = nba_service.get_current_season()
+        timestamp = "2026-03-25T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("0022501042", timestamp)
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "03/25/2026 00:00:00",
+            [
+                _make_schedule_game(
+                    "0022501042",
+                    timestamp,
+                    arenaName="Little Caesars Arena",
+                    arenaCity="Detroit",
+                    arenaState="MI",
+                )
+            ],
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        row = result[result["game_id"] == "0022501042"].iloc[0]
+        assert row["arena_name"] == "Little Caesars Arena"
+        assert row["arena_city"] == "Detroit"
+        assert row["arena_state"] == "MI"
+
+
+class TestLiveFieldsOverlay:
+    """Gamecardfeed live fields override schedule fields for today's games."""
+
+    @pytest.mark.asyncio
+    async def test_live_status_overrides_schedule_status(self, nba_service):
+        season = nba_service.get_current_season()
+        timestamp = "2026-03-25T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("0022501042", timestamp)  # status=2, INGAME
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "03/25/2026 00:00:00",
+            [_make_schedule_game("0022501042", timestamp)],  # status=1, PREGAME in schedule
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        row = result[result["game_id"] == "0022501042"].iloc[0]
+        assert row["status"] == NBAGameStatus.INGAME
+
+    @pytest.mark.asyncio
+    async def test_live_scores_override_schedule_scores(self, nba_service):
+        season = nba_service.get_current_season()
+        timestamp = "2026-03-25T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("0022501042", timestamp)  # home=55, away=50
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "03/25/2026 00:00:00",
+            [_make_schedule_game("0022501042", timestamp)],  # scores both 0 in schedule
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        row = result[result["game_id"] == "0022501042"].iloc[0]
+        assert row["home_score"] == 55
+        assert row["away_score"] == 50
+
+    @pytest.mark.asyncio
+    async def test_schedule_only_games_unaffected_by_overlay(self, nba_service):
+        """Historical games not in the gamecardfeed keep their schedule data intact."""
+        season = nba_service.get_current_season()
+        live_ts = "2026-03-25T23:00:00Z"
+        hist_ts = "2026-03-24T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("today_game", live_ts)
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "03/25/2026 00:00:00",
+            [
+                _make_schedule_game("hist_game", hist_ts),
+                _make_schedule_game("today_game", live_ts),
+            ],
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        assert len(result) == 2
+        hist = result[result["game_id"] == "hist_game"].iloc[0]
+        assert hist["status"] == NBAGameStatus.PREGAME  # unchanged from schedule
+
+
+class TestGameDateParsing:
+    """gameDate in MM/DD/YYYY HH:MM:SS format is handled correctly."""
+
+    @pytest.mark.asyncio
+    async def test_game_date_mm_dd_yyyy_format(self, nba_service):
+        """Schedule gameDates in MM/DD/YYYY HH:MM:SS format parse without error."""
+        season = nba_service.get_current_season()
+        timestamp = "2026-03-25T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("0022501042", timestamp)
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "03/25/2026 00:00:00",
+            [_make_schedule_game("0022501042", timestamp)],
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        assert len(result) == 1
+        assert result.iloc[0]["game_id"] == "0022501042"
+
+    @pytest.mark.asyncio
+    async def test_game_date_future_dates_excluded(self, nba_service):
+        """Games in gameDates blocks after scoreboard_date are not included."""
+        season = nba_service.get_current_season()
+        today_ts = "2026-03-25T23:00:00Z"
+        future_ts = "2026-03-27T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("today_game", today_ts)
+        cdn_schedule_raw = {
+            "leagueSchedule": {
+                "seasonYear": season,
+                "gameDates": [
+                    {
+                        "gameDate": "03/25/2026 00:00:00",
+                        "games": [_make_schedule_game("today_game", today_ts)],
+                    },
+                    {
+                        "gameDate": "03/27/2026 00:00:00",
+                        "games": [_make_schedule_game("future_game", future_ts)],
+                    },
+                ],
+            }
+        }
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        assert "future_game" not in result["game_id"].values

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -458,17 +458,17 @@ class TestGameUrl:
 
         assert result["game_url"] == "https://www.nba.com/game/atl-vs-det-0022501042"
 
-    def test_url_constructed_from_slugs_when_no_share_url(self, nba_service):
+    def test_url_none_when_no_share_url(self, nba_service):
         game = {
             "gameId": "0022501051",
             "gameStatus": 1,
-            "homeTeam": {"teamId": 1610612765, "teamTricode": "DET", "teamSlug": "pistons", "score": 0},
-            "awayTeam": {"teamId": 1610612737, "teamTricode": "ATL", "teamSlug": "hawks", "score": 0},
+            "homeTeam": {"teamId": 1, "teamTricode": "DET", "score": 0},
+            "awayTeam": {"teamId": 2, "teamTricode": "ATL", "score": 0},
             "gameStatusText": "7:00 pm ET",
         }
         result = nba_service._parse_game_data(game, "2026-03-25T23:00:00Z")
 
-        assert result["game_url"] == "https://www.nba.com/game/hawks-vs-pistons-0022501051"
+        assert result["game_url"] is None
 
     @pytest.mark.asyncio
     async def test_gamecardfeed_share_url_overrides_schedule_null(self, nba_service):

--- a/frontend/src/components/pool/TodayGames.vue
+++ b/frontend/src/components/pool/TodayGames.vue
@@ -116,6 +116,11 @@ function fmtPct(p: number): string {
           {{ fmtPct(game.home_win_pct) }}
         </span>
       </div>
+
+      <!-- Arena -->
+      <p v-if="game.arena_name" class="text-xs text-surface-500 mt-1.5">
+        {{ game.arena_name }} · {{ game.arena_city }}, {{ game.arena_state }}
+      </p>
     </div>
   </div>
 </template>

--- a/frontend/src/components/pool/TodayGames.vue
+++ b/frontend/src/components/pool/TodayGames.vue
@@ -117,10 +117,21 @@ function fmtPct(p: number): string {
         </span>
       </div>
 
-      <!-- Arena -->
-      <p v-if="game.arena_name" class="text-xs text-surface-500 mt-1.5">
-        {{ game.arena_name }} · {{ game.arena_city }}, {{ game.arena_state }}
-      </p>
+      <!-- Arena + broadcaster logos -->
+      <div class="flex items-center justify-between mt-1.5">
+        <p v-if="game.arena_name" class="text-xs text-surface-500">
+          {{ game.arena_name }} · {{ game.arena_city }}, {{ game.arena_state }}
+        </p>
+        <div class="flex items-center gap-1 ml-auto">
+          <img
+            v-for="logo in game.national_broadcaster_logos ?? []"
+            :key="logo"
+            :src="logo"
+            class="h-3.5 opacity-60"
+          />
+
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/frontend/src/components/pool/TodayGames.vue
+++ b/frontend/src/components/pool/TodayGames.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { formatUTCTime } from '../../utils/time'
 import type { TodayGame } from '../../types/leaderboard'
 
 const props = defineProps<{
@@ -8,6 +9,9 @@ const props = defineProps<{
 function statusLabel(game: TodayGame): string {
   if (game.status === 2) return game.status_text || 'LIVE'
   if (game.status === 3) return 'Final'
+  if (game.game_time) {
+    return formatUTCTime(game.game_time, { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' })
+  }
   return game.status_text || ''
 }
 
@@ -26,7 +30,9 @@ function todayRecord(wins: number | null, losses: number | null): string | null 
   return `${wins}-${losses}`
 }
 
-
+function fmtPct(p: number): string {
+  return Math.round(p * 100) + '%'
+}
 </script>
 
 <template>
@@ -73,6 +79,10 @@ function todayRecord(wins: number | null, losses: number | null): string | null 
           }">
           {{ game.away_score }}
         </span>
+        <span v-else-if="game.status === 1 && game.away_win_pct !== null"
+          class="text-sm font-semibold tabular-nums flex-shrink-0 text-surface-300">
+          {{ fmtPct(game.away_win_pct) }}
+        </span>
       </div>
 
       <!-- Home team -->
@@ -100,6 +110,10 @@ function todayRecord(wins: number | null, losses: number | null): string | null 
             'text-surface-400': game.status === 3 && !isWinner(game.home_score, game.away_score, game.status),
           }">
           {{ game.home_score }}
+        </span>
+        <span v-else-if="game.status === 1 && game.home_win_pct !== null"
+          class="text-sm font-semibold tabular-nums flex-shrink-0 text-surface-300">
+          {{ fmtPct(game.home_win_pct) }}
         </span>
       </div>
     </div>

--- a/frontend/src/types/leaderboard.ts
+++ b/frontend/src/types/leaderboard.ts
@@ -53,6 +53,7 @@ export interface TodayGame {
   arena_name: string | null
   arena_city: string | null
   arena_state: string | null
+  national_broadcaster_logos: string[] | null
   home_team_id: number | null
   home_team_name: string
   home_team_tricode: string

--- a/frontend/src/types/leaderboard.ts
+++ b/frontend/src/types/leaderboard.ts
@@ -50,6 +50,9 @@ export interface TodayGame {
   game_time: string | null
   home_win_pct: number | null
   away_win_pct: number | null
+  arena_name: string | null
+  arena_city: string | null
+  arena_state: string | null
   home_team_id: number | null
   home_team_name: string
   home_team_tricode: string

--- a/frontend/src/types/leaderboard.ts
+++ b/frontend/src/types/leaderboard.ts
@@ -47,6 +47,9 @@ export interface TodayGame {
   status: 1 | 2 | 3 // 1=PREGAME, 2=INGAME, 3=FINAL
   status_text: string
   game_clock: string
+  game_time: string | null
+  home_win_pct: number | null
+  away_win_pct: number | null
   home_team_id: number | null
   home_team_name: string
   home_team_tricode: string


### PR DESCRIPTION
- Converted game time to local timezone
- Show pre-game implied probabilities from Fanduel odds
- Show game location to make it clear which team is home
- Added broadcast logos for national TV games

<img width="400" alt="localhost_5173_pools_sg_season_2025-26_tab=today(iPhone 12 Pro) (3)" src="https://github.com/user-attachments/assets/bcf5ac0a-55d5-4178-9ecb-e47da88dd8c2" />
