### PR TITLE
fix: skip FanDuel fetch and calibration during live games

### DIFF
--- a/backend/src/nba_wins_pool/job_definitions.py
+++ b/backend/src/nba_wins_pool/job_definitions.py
@@ -7,11 +7,6 @@ from typing import Awaitable, Callable
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
-from nba_wins_pool.repositories.nba_projections_repository import NBAProjectionsRepository
-from nba_wins_pool.repositories.team_repository import TeamRepository
-from nba_wins_pool.services.nba_espn_projections_service import NBAEspnProjectionsService
-from nba_wins_pool.services.nba_vegas_projections_service import NBAVegasProjectionsService
-
 logger = logging.getLogger(__name__)
 
 
@@ -43,40 +38,10 @@ class ScheduledJob:
 # Job functions
 async def fetch_nba_projections_job(db_session_factory):
     """Fetch NBA projections from FanDuel and ESPN, then run a calibrated simulation."""
-    from nba_wins_pool.services.nba_simulator.nba_simulator_service import run_and_save_simulation
+    from nba_wins_pool.services.nba_simulator.nba_simulator_service import run_projections_and_simulation
 
     async for db in db_session_factory():
-        team_repo = TeamRepository(db)
-        nba_projections_repo = NBAProjectionsRepository(db)
-
-        # FanDuel (Vegas) service
-        vegas_service = NBAVegasProjectionsService(
-            db_session=db,
-            team_repository=team_repo,
-            nba_projections_repository=nba_projections_repo,
-        )
-
-        # ESPN service
-        espn_service = NBAEspnProjectionsService(
-            db_session=db,
-            team_repository=team_repo,
-            nba_projections_repository=nba_projections_repo,
-        )
-
-        # Fetch and write projections
-        vegas_count = await vegas_service.write_projections()
-        espn_count = await espn_service.write_projections()
-
-        logger.info(f"FanDuel projections fetch completed. Successfully wrote {vegas_count} records.")
-        logger.info(f"ESPN BPI projections fetch completed. Successfully wrote {espn_count} records.")
-
-        # Expire all cached ORM state so the simulation reads the just-committed rows.
-        db.expire_all()
-
-        logger.info("Running calibrated simulation with fresh projections...")
-        await run_and_save_simulation(db, calibrate=True)
-        logger.info("Simulation completed.")
-
+        await run_projections_and_simulation(db)
         break
 
 

--- a/backend/src/nba_wins_pool/job_definitions.py
+++ b/backend/src/nba_wins_pool/job_definitions.py
@@ -7,6 +7,8 @@ from typing import Awaitable, Callable
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
+from nba_wins_pool.services.nba_simulator.nba_simulator_service import run_projections_and_simulation
+
 logger = logging.getLogger(__name__)
 
 
@@ -38,8 +40,6 @@ class ScheduledJob:
 # Job functions
 async def fetch_nba_projections_job(db_session_factory):
     """Fetch NBA projections from FanDuel and ESPN, then run a calibrated simulation."""
-    from nba_wins_pool.services.nba_simulator.nba_simulator_service import run_projections_and_simulation
-
     async for db in db_session_factory():
         await run_projections_and_simulation(db)
         break

--- a/backend/src/nba_wins_pool/scripts/run_simulation.py
+++ b/backend/src/nba_wins_pool/scripts/run_simulation.py
@@ -1,52 +1,13 @@
 #!/usr/bin/env python3
 """Script to run the NBA season Monte Carlo simulation and persist results."""
 
-import argparse
 import asyncio
 import logging
-import sys
 
 from nba_wins_pool.db.core import get_db_session
 from nba_wins_pool.job_definitions import fetch_nba_projections_job
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-logger = logging.getLogger("run_simulation")
-
-
-async def main(calibrate: bool, fetch_projections: bool):
-    if fetch_projections:
-        logger.info("Fetching fresh NBA projections (FanDuel + ESPN)...")
-        try:
-            await fetch_nba_projections_job(get_db_session)
-        except Exception as e:
-            logger.error(f"Projections fetch failed: {e}", exc_info=True)
-            sys.exit(1)
-
-    from nba_wins_pool.services.nba_simulator.nba_simulator_service import run_and_save_simulation
-
-    logger.info("Starting NBA season simulation (calibrate=%s)...", calibrate)
-    try:
-        async for db in get_db_session():
-            await run_and_save_simulation(db, calibrate=calibrate)
-            break
-    except Exception as e:
-        logger.error(f"Simulation failed: {e}", exc_info=True)
-        sys.exit(1)
-
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Run the NBA season Monte Carlo simulation.")
-    parser.add_argument(
-        "--no-calibrate",
-        action="store_true",
-        dest="no_calibrate",
-        help="Skip calibration against Vegas odds (faster; stores raw ESPN BPI as power rating).",
-    )
-    parser.add_argument(
-        "--fetch-projections",
-        action="store_true",
-        help="Fetch fresh FanDuel and ESPN projections before running the simulation.",
-    )
-    args = parser.parse_args()
-
-    asyncio.run(main(calibrate=not args.no_calibrate, fetch_projections=args.fetch_projections))
+    asyncio.run(fetch_nba_projections_job(get_db_session))

--- a/backend/src/nba_wins_pool/services/nba_simulator/nba_simulator_service.py
+++ b/backend/src/nba_wins_pool/services/nba_simulator/nba_simulator_service.py
@@ -257,6 +257,7 @@ async def _simulate_postseason_phase(
             len(calibrated_ratings),
         )
     else:
+        calibrated_ratings = dict(playoff_bpi) if playoff_bpi else {}
         logger.info("Calibration skipped; no stored ratings found, falling back to raw ESPN BPI")
 
     po_result: PlayoffSimResult = run_playoff_simulation(
@@ -490,8 +491,14 @@ async def run_and_save_simulation(db_session: AsyncSession, *, calibrate: bool =
     sim_repo = SimulationResultsRepository(db_session)
     team_repo = TeamRepository(db_session)
 
-    # Fetch ESPN playoff BPI once and reuse across calibration + result persistence.
-    playoff_bpi = await projections_repo.get_latest_playoff_bpi()
+    # Use stored calibrated power ratings if available; fall back to ESPN BPI.
+    warm_start_ratings, _ = await _load_warm_start_ratings(sim_repo, team_repo, season)
+    if warm_start_ratings:
+        logger.info("Using %d stored calibrated power ratings as playoff BPI", len(warm_start_ratings))
+        playoff_bpi = warm_start_ratings
+    else:
+        logger.info("No stored ratings found; fetching ESPN playoff BPI")
+        playoff_bpi = await projections_repo.get_latest_playoff_bpi()
 
     output = await simulate_nba_season(
         nba_service,
@@ -516,6 +523,53 @@ async def run_and_save_simulation(db_session: AsyncSession, *, calibrate: bool =
     )
 
     logger.info("Simulation completed for season %s phase %s", season, output.phase)
+
+
+async def run_projections_and_simulation(db_session: AsyncSession) -> None:
+    """Fetch fresh projections (when no games are live) then run the simulation.
+
+    If games are currently in progress, skips the FanDuel fetch to avoid
+    incomplete futures odds and runs without calibration using the most recently
+    stored power ratings instead.
+    """
+    from nba_wins_pool.repositories.external_data_repository import ExternalDataRepository
+    from nba_wins_pool.repositories.nba_projections_repository import NBAProjectionsRepository
+    from nba_wins_pool.repositories.team_repository import TeamRepository
+    from nba_wins_pool.services.nba_data_service import NbaDataService
+    from nba_wins_pool.services.nba_espn_projections_service import NBAEspnProjectionsService
+    from nba_wins_pool.services.nba_simulator.data import get_nba_schedule
+    from nba_wins_pool.services.nba_vegas_projections_service import NBAVegasProjectionsService
+    from nba_wins_pool.types.nba_game_status import NBAGameStatus
+
+    nba_service = NbaDataService(db_session=db_session, external_data_repository=ExternalDataRepository(db_session))
+    schedule = get_nba_schedule(nba_service)
+
+    if (schedule["status"] == NBAGameStatus.INGAME).any():
+        logger.info("Games in progress — skipping FanDuel fetch and running without calibration.")
+        await run_and_save_simulation(db_session, calibrate=False)
+        return
+
+    team_repo = TeamRepository(db_session)
+    projections_repo = NBAProjectionsRepository(db_session)
+
+    vegas_count = await NBAVegasProjectionsService(
+        db_session=db_session,
+        team_repository=team_repo,
+        nba_projections_repository=projections_repo,
+    ).write_projections()
+    espn_count = await NBAEspnProjectionsService(
+        db_session=db_session,
+        team_repository=team_repo,
+        nba_projections_repository=projections_repo,
+    ).write_projections()
+
+    logger.info("FanDuel projections fetch completed. Successfully wrote %d records.", vegas_count)
+    logger.info("ESPN BPI projections fetch completed. Successfully wrote %d records.", espn_count)
+
+    db_session.expire_all()
+
+    logger.info("Running calibrated simulation with fresh projections...")
+    await run_and_save_simulation(db_session, calibrate=True)
 
 
 async def compare_simulated_vs_market(

--- a/backend/src/nba_wins_pool/services/nba_simulator/nba_simulator_service.py
+++ b/backend/src/nba_wins_pool/services/nba_simulator/nba_simulator_service.py
@@ -20,6 +20,7 @@ from nba_wins_pool.repositories.roster_slot_repository import RosterSlotReposito
 from nba_wins_pool.repositories.simulation_results_repository import SimulationResultsRepository
 from nba_wins_pool.repositories.team_repository import TeamRepository
 from nba_wins_pool.services.nba_data_service import NbaDataService
+from nba_wins_pool.services.nba_espn_projections_service import NBAEspnProjectionsService
 from nba_wins_pool.services.nba_simulator.calibration import (
     CalibrationResult,
     calibrate_ratings,
@@ -42,6 +43,7 @@ from nba_wins_pool.services.nba_simulator.regular_season_sim import (
     run_playoff_simulation,
     run_regular_season_simulation,
 )
+from nba_wins_pool.services.nba_vegas_projections_service import NBAVegasProjectionsService
 from nba_wins_pool.types.nba_game_status import NBAGameStatus
 from nba_wins_pool.types.nba_game_type import NBAGameType
 from nba_wins_pool.utils.time import utc_now
@@ -532,15 +534,6 @@ async def run_projections_and_simulation(db_session: AsyncSession) -> None:
     incomplete futures odds and runs without calibration using the most recently
     stored power ratings instead.
     """
-    from nba_wins_pool.repositories.external_data_repository import ExternalDataRepository
-    from nba_wins_pool.repositories.nba_projections_repository import NBAProjectionsRepository
-    from nba_wins_pool.repositories.team_repository import TeamRepository
-    from nba_wins_pool.services.nba_data_service import NbaDataService
-    from nba_wins_pool.services.nba_espn_projections_service import NBAEspnProjectionsService
-    from nba_wins_pool.services.nba_simulator.data import get_nba_schedule
-    from nba_wins_pool.services.nba_vegas_projections_service import NBAVegasProjectionsService
-    from nba_wins_pool.types.nba_game_status import NBAGameStatus
-
     nba_service = NbaDataService(db_session=db_session, external_data_repository=ExternalDataRepository(db_session))
     schedule = get_nba_schedule(nba_service)
 

--- a/backend/tests/test_job_definitions.py
+++ b/backend/tests/test_job_definitions.py
@@ -13,33 +13,18 @@ from nba_wins_pool.services.scheduler_service import SchedulerService
 
 @pytest.mark.asyncio
 async def test_fetch_nba_projections_job():
-    """Test NBA projections fetch job writes projections then runs a calibrated simulation."""
+    """Test that the job delegates entirely to run_projections_and_simulation."""
     mock_db = MagicMock()
 
     async def mock_factory():
         yield mock_db
 
-    with (
-        patch("nba_wins_pool.job_definitions.NBAVegasProjectionsService") as MockVegasService,
-        patch("nba_wins_pool.job_definitions.NBAEspnProjectionsService") as MockEspnService,
-        patch(
-            "nba_wins_pool.services.nba_simulator.nba_simulator_service.run_and_save_simulation",
-            new=AsyncMock(),
-        ) as mock_run_sim,
-    ):
-        mock_vegas_service = MockVegasService.return_value
-        mock_vegas_service.write_projections = AsyncMock(return_value=10)
-
-        mock_espn_service = MockEspnService.return_value
-        mock_espn_service.write_projections = AsyncMock(return_value=5)
-
+    with patch(
+        "nba_wins_pool.job_definitions.run_projections_and_simulation",
+        new=AsyncMock(),
+    ) as mock_run:
         await fetch_nba_projections_job(mock_factory)
-
-        MockVegasService.assert_called_once()
-        MockEspnService.assert_called_once()
-        mock_vegas_service.write_projections.assert_called_once()
-        mock_espn_service.write_projections.assert_called_once()
-        mock_run_sim.assert_awaited_once_with(mock_db, calibrate=True)
+        mock_run.assert_awaited_once_with(mock_db)
 
 
 def test_scheduled_jobs_registry():


### PR DESCRIPTION
## Problem

During live playoff games, FanDuel temporarily removes futures odds for teams that are actively playing. This caused two issues:

1. **Inconsistent simulation results between the scheduled job and the manual script** — the script was calling \`fetch_nba_projections_job\` (which fetches projections *and* runs the simulation) and then running the simulation a second time. The second run warm-started calibration from the first run's saved ratings, causing the optimizer to land in a different local minimum and producing consistently different results.

2. **Unstable calibration when odds are missing mid-game** — when ATL (or any team) has a live game, their futures odds disappear from FanDuel. The calibration optimizer runs without that team's constraint, which shifts the optimization landscape and causes other teams' power ratings to swing significantly between hourly runs.

## Changes

### `run_simulation.py` — script now matches the job exactly
The script previously had its own logic (with `--fetch-projections` / `--no-calibrate` flags) that diverged from the job. It now just calls `fetch_nba_projections_job` directly, guaranteeing identical behavior.

### `nba_simulator_service.py` — new `run_projections_and_simulation` orchestration function
Encapsulates the full job logic (previously spread across `job_definitions.py`):
- Checks the live schedule for `INGAME` games before fetching anything
- **If games are in progress**: skips the FanDuel futures fetch entirely and runs the simulation with `calibrate=False`, using the most recently stored calibrated power ratings
- **If no games are in progress**: fetches fresh FanDuel + ESPN projections, then runs with `calibrate=True` as before

Also fixes a pre-existing bug in `_simulate_postseason_phase`: the `else` branch (no stored ratings, calibration skipped) logged "falling back to raw ESPN BPI" but never actually set `calibrated_ratings`, causing a `ValueError` in `run_playoff_simulation` when no stored ratings existed.

Additionally, `run_and_save_simulation` now prefers stored calibrated power ratings over raw ESPN BPI as the `playoff_bpi` input, falling back to ESPN BPI only on the first ever run.

### `job_definitions.py` — thinned to a scheduler registration file
All job logic moved into the service layer. The job definition now just calls `run_projections_and_simulation`.

## Test plan
- [ ] Verify simulation runs cleanly when no games are in progress (full fetch + calibrate)
- [ ] Verify simulation runs cleanly when games are in progress (skips fetch, uses stored ratings)
- [ ] Verify manual script produces the same results as the scheduled job

🤖 Generated with [Claude Code](https://claude.com/claude-code)