### PR TITLE
fix: season phase detection and simulation edge cases

### DIFF
--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -203,11 +203,14 @@ class LeaderboardService:
                 )
                 # Re-sort with sim expected_wins, keeping Undrafted at end
                 undrafted_mask = roster_standings_df["name"] == UNDRAFTED_ROSTER_NAME
+                sort_cols = ["wins", "losses"]
+                ascending = [False, True]
+                if "expected_wins" in roster_standings_df.columns:
+                    sort_cols.append("expected_wins")
+                    ascending.append(False)
                 roster_standings_df = pd.concat(
                     [
-                        roster_standings_df[~undrafted_mask].sort_values(
-                            by=["wins", "losses", "expected_wins"], ascending=[False, True, False]
-                        ),
+                        roster_standings_df[~undrafted_mask].sort_values(by=sort_cols, ascending=ascending),
                         roster_standings_df[undrafted_mask],
                     ]
                 ).reset_index(drop=True)

--- a/backend/src/nba_wins_pool/services/nba_simulator/data.py
+++ b/backend/src/nba_wins_pool/services/nba_simulator/data.py
@@ -98,11 +98,13 @@ def detect_season_phase(schedule: pd.DataFrame) -> NBAGameType:
         The current ``NBAGameType`` phase.
     """
     pregame = schedule[schedule["status"] == NBAGameStatus.PREGAME]
-    game_types = set(pregame["game_type"])
-    if NBAGameType.PLAY_IN in game_types:
-        return NBAGameType.PLAY_IN
-    if NBAGameType.PLAYOFFS in game_types:
-        return NBAGameType.PLAYOFFS
+    if not pregame.empty:
+        game_types = set(pregame["game_type"])
+        if NBAGameType.PLAY_IN in game_types:
+            return NBAGameType.PLAY_IN
+        if NBAGameType.PLAYOFFS in game_types:
+            return NBAGameType.PLAYOFFS
+        return NBAGameType.REGULAR_SEASON
 
     # Fallback to all games if there are no pregame games (e.g. season is over, or finals are currently ingame)
     all_game_types = set(schedule["game_type"])

--- a/backend/src/nba_wins_pool/services/nba_simulator/data.py
+++ b/backend/src/nba_wins_pool/services/nba_simulator/data.py
@@ -104,6 +104,13 @@ def detect_season_phase(schedule: pd.DataFrame) -> NBAGameType:
     if NBAGameType.PLAYOFFS in game_types:
         return NBAGameType.PLAYOFFS
 
+    # Fallback to all games if there are no pregame games (e.g. season is over, or finals are currently ingame)
+    all_game_types = set(schedule["game_type"])
+    if NBAGameType.PLAYOFFS in all_game_types:
+        return NBAGameType.PLAYOFFS
+    if NBAGameType.PLAY_IN in all_game_types:
+        return NBAGameType.PLAY_IN
+
     return NBAGameType.REGULAR_SEASON
 
 

--- a/backend/src/nba_wins_pool/services/nba_simulator/regular_season_sim.py
+++ b/backend/src/nba_wins_pool/services/nba_simulator/regular_season_sim.py
@@ -180,7 +180,12 @@ def run_regular_season_simulation(
     if game_df.empty:
         all_tricodes = sorted(current_wins.index.tolist()) if len(current_wins) > 0 else []
         rs_wins_sim = np.array([[current_wins.get(tc, 0)] * n_sims for tc in all_tricodes], dtype=np.float32)
-        stats = pd.DataFrame(columns=["tricode", "mean_wins"])
+        stats = pd.DataFrame(
+            {
+                "tricode": all_tricodes,
+                "mean_wins": [float(current_wins.get(tc, 0)) for tc in all_tricodes],
+            }
+        )
         seeding = compute_playoff_seeds(
             completed,
             game_df,

--- a/backend/tests/test_nba_simulator_data.py
+++ b/backend/tests/test_nba_simulator_data.py
@@ -104,12 +104,12 @@ class TestDetectSeasonPhase:
         # Re-check the logic: PLAY_IN checked before PLAYOFFS → returns PLAY_IN
         assert detect_season_phase(schedule) == NBAGameType.PLAY_IN
 
-    def test_completed_games_not_counted(self):
-        # All final games; no PREGAME entries → regular season
+    def test_completed_playoffs_returns_playoffs(self):
+        # All final games; no PREGAME entries → fallback checks all games, should be PLAYOFFS
         schedule = _make_schedule(
             {"status": NBAGameStatus.FINAL, "game_type": NBAGameType.PLAYOFFS},
         )
-        assert detect_season_phase(schedule) == NBAGameType.REGULAR_SEASON
+        assert detect_season_phase(schedule) == NBAGameType.PLAYOFFS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes an issue where running `run_projections_and_simulation` would silently fail to write database records if no upcoming pregame games were found, and fixes a resulting `KeyError` on the leaderboard endpoint.

### Changes Made
1. **`detect_season_phase`**: Falls back to looking at the entire schedule if no `PREGAME` playoff or play-in games exist to properly classify the current phase as `PLAYOFFS` or `PLAY_IN` instead of defaulting to `REGULAR_SEASON` incorrectly.
2. **`run_regular_season_simulation`**: Prevents the `win_stats` DataFrame from being empty if no regular season games are remaining. Now properly populates it with the current actual team wins.
3. **`leaderboard_service.py`**: Conditionally includes the `expected_wins` column in the standings sort logic only if it exists in the DataFrame, preventing a `KeyError` when simulation roster results are empty.