### PR TITLE
feat: programmatic wins race milestones + chart improvements

### DIFF
--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -253,6 +253,116 @@ class NbaDataService:
         start_year_str = season_year.split("-")[0]
         return int(start_year_str) + 1
 
+    @staticmethod
+    def _get_all_star_date_from_schedule(raw_schedule: dict) -> str | None:
+        """Find the last regular-season game date before the All-Star break.
+
+        Detects the break by watching for a run of game dates that contain only
+        All-Star/Rising Stars events (no regular games). Returns the last date
+        before that run that had at least one regular game. Does not rely on the
+        weeks[] array, which may use different names across seasons.
+
+        Args:
+            raw_schedule: Raw schedule dict from NBA API (scheduleleaguev2 format).
+
+        Returns:
+            Date string in YYYY-MM-DD format, or None if no All-Star break is detected.
+        """
+        exclude_keywords = ["All-Star", "Rising Stars"]
+        last_regular_date: date | None = None
+        in_all_star_break = False
+
+        for game_date_entry in raw_schedule.get("leagueSchedule", {}).get("gameDates", []):
+            raw_date = game_date_entry.get("gameDate", "")
+            try:
+                game_dt = datetime.strptime(raw_date[:10], "%m/%d/%Y").date()
+            except ValueError:
+                continue
+
+            games = game_date_entry.get("games", [])
+            has_regular_game = any(not any(kw in (g.get("gameLabel") or "") for kw in exclude_keywords) for g in games)
+            has_all_star_game = any(any(kw in (g.get("gameLabel") or "") for kw in exclude_keywords) for g in games)
+
+            if in_all_star_break and has_regular_game:
+                break
+
+            if has_all_star_game and not has_regular_game:
+                in_all_star_break = True
+
+            if has_regular_game:
+                last_regular_date = game_dt
+
+        return last_regular_date.strftime("%Y-%m-%d") if in_all_star_break and last_regular_date else None
+
+    @staticmethod
+    def _get_regular_season_end_date(season_type_dates: list[tuple[NBAGameType, datetime, datetime]]) -> str | None:
+        """Extract the Regular Season end date from ESPN season type date ranges.
+
+        Args:
+            season_type_dates: Output of ``_fetch_espn_season_type_dates``.
+
+        Returns:
+            Date string in YYYY-MM-DD format, or None if Regular Season is not found.
+        """
+        for game_type, _start, end in season_type_dates:
+            if game_type == NBAGameType.REGULAR_SEASON:
+                return end.strftime("%Y-%m-%d")
+        return None
+
+    async def _get_raw_schedule_cached(self, season_year: str) -> dict:
+        """Get the raw schedule dict for a season, using the DB cache when available.
+
+        Args:
+            season_year: Season string in format YYYY-YY.
+
+        Returns:
+            Raw schedule dictionary from NBA API.
+        """
+        if season_year == self.get_current_season():
+            _, raw_schedule = await asyncio.to_thread(self._fetch_current_season_raw)
+            return raw_schedule
+        key = f"nba:schedule:{season_year}"
+        cached = await self.repo.get_by_key(key)
+        if cached:
+            return cached.data_json
+        raw = await asyncio.to_thread(self._fetch_schedule_raw, season_year)
+        await self._store_data(key, raw)
+        return raw
+
+    async def get_season_milestones(self, season_year: str) -> list[dict]:
+        """Build milestone markers for the wins race chart for a given season.
+
+        Derives the All-Star Break date from the NBA schedule and the Playoffs start
+        date from the ESPN Regular Season end date. Returns an empty list on failure.
+
+        Args:
+            season_year: Season string in format YYYY-YY.
+
+        Returns:
+            List of milestone dicts with slug, date (YYYY-MM-DD), and description keys,
+            sorted chronologically.
+        """
+        milestones = []
+
+        try:
+            raw_schedule = await self._get_raw_schedule_cached(season_year)
+            all_star_date = self._get_all_star_date_from_schedule(raw_schedule)
+            if all_star_date:
+                milestones.append({"slug": "all_star_break", "date": all_star_date, "description": "All-Star Break"})
+        except Exception:
+            logger.warning("Failed to extract All-Star date for %s", season_year, exc_info=True)
+
+        try:
+            season_type_dates = self._get_espn_season_type_dates(season_year)
+            if season_type_dates:
+                reg_end = self._get_regular_season_end_date(season_type_dates)
+                if reg_end:
+                    milestones.append({"slug": "playoffs_start", "date": reg_end, "description": "Playoffs"})
+        except Exception:
+            logger.warning("Failed to extract Playoffs date for %s", season_year, exc_info=True)
+
+        return sorted(milestones, key=lambda m: m["date"])
+
     def _parse_game_data(
         self, game: dict, game_timestamp: str, game_type: NBAGameType = NBAGameType.REGULAR_SEASON
     ) -> dict:
@@ -415,6 +525,8 @@ class NbaDataService:
                         game_type = self._classify_game_date(game_dt, season_type_dates)
                     else:
                         game_type = NBAGameType.REGULAR_SEASON
+                    if game_type == NBAGameType.PRESEASON:
+                        continue
                     game_data.append(
                         self._parse_game_data(game, game[self.SCHEDULE_GAME_TIME_KEY], game_type=game_type)
                     )

--- a/backend/src/nba_wins_pool/services/wins_race_service.py
+++ b/backend/src/nba_wins_pool/services/wins_race_service.py
@@ -29,17 +29,6 @@ from nba_wins_pool.types.season_str import SeasonStr
 
 UNDRAFTED_ROSTER_NAME = "Undrafted"
 
-# Season milestones
-# TODO: Move to database table for better management
-SEASON_MILESTONES = {
-    "2024-25": [
-        {"slug": "all_star_break_start", "date": "2025-02-14", "description": "All-Star Break"},
-        {"slug": "regular_season_end", "date": "2025-04-13", "description": "Regular Season Ends"},
-        {"slug": "playoffs_start", "date": "2025-04-19", "description": "Playoffs Start"},
-    ],
-    # Add future seasons as needed
-}
-
 
 class WinsRaceService:
     def __init__(
@@ -69,7 +58,7 @@ class WinsRaceService:
         roster_names = mappings.roster_names
 
         roster_metadata = self._build_roster_metadata(roster_names)
-        milestones_metadata = self._load_milestones(season)
+        milestones_metadata = await self._load_milestones(season)
 
         # Handle empty games case
         if game_df.empty:
@@ -162,11 +151,11 @@ class WinsRaceService:
         unique_names = sorted({name for name in roster_names if name != UNDRAFTED_ROSTER_NAME})
         return [{"name": name} for name in unique_names]
 
-    def _load_milestones(self, season_year: str | None) -> list[dict[str, Any]]:
-        """Load milestones for a given season from the SEASON_MILESTONES dictionary."""
+    async def _load_milestones(self, season_year: str | None) -> list[dict[str, Any]]:
+        """Load milestones for a given season from the NBA schedule and ESPN season data."""
         if not season_year:
             return []
-        return SEASON_MILESTONES.get(season_year, [])
+        return await self.nba_data_service.get_season_milestones(season_year)
 
 
 async def get_wins_race_service(

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -161,7 +161,10 @@ class TestGetGameData:
             }
         }
 
-        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+        with (
+            patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)),
+            patch.object(nba_service, "_get_espn_season_type_dates", return_value=None),
+        ):
             result = await nba_service.get_game_data(season)
 
         assert isinstance(result, pd.DataFrame)
@@ -1078,3 +1081,164 @@ class TestGameTypeInParsedSchedule:
         )
         games = nba_service._parse_schedule(raw)
         assert games[0]["game_type"] == NBAGameType.REGULAR_SEASON
+
+    def test_preseason_games_excluded(self, nba_service, season_type_dates):
+        """Preseason games must not appear in parsed results — they would inflate leaderboard win counts."""
+        # Preseason window in fixture: Oct 1–21 2025. Regular season starts Oct 21 2025.
+        raw = {
+            "leagueSchedule": {
+                "seasonYear": "2025-26",
+                "gameDates": [
+                    {
+                        "gameDate": "10/05/2025 00:00:00",
+                        "games": [_make_schedule_game("preseason_game", "2025-10-05T23:00:00Z")],
+                    },
+                    {
+                        "gameDate": "11/01/2025 00:00:00",
+                        "games": [_make_schedule_game("regular_game", "2025-11-01T00:30:00Z")],
+                    },
+                ],
+            }
+        }
+        games = nba_service._parse_schedule(raw, season_type_dates=season_type_dates)
+        game_ids = [g["game_id"] for g in games]
+        assert "preseason_game" not in game_ids
+        assert "regular_game" in game_ids
+        assert len(games) == 1
+
+
+class TestSeasonMilestones:
+    """Tests for All-Star and Playoffs milestone extraction."""
+
+    def _make_schedule(self, game_dates: list[dict]) -> dict:
+        return {"leagueSchedule": {"seasonYear": "2025-26", "gameDates": game_dates}}
+
+    def _make_game_date(self, date_str: str, game_labels: list[str]) -> dict:
+        """date_str in MM/DD/YYYY format."""
+        return {
+            "gameDate": f"{date_str} 00:00:00",
+            "games": [{"gameLabel": label, "gameId": f"g_{date_str}_{i}"} for i, label in enumerate(game_labels)],
+        }
+
+    def test_all_star_date_is_last_regular_game_before_break(self, nba_service):
+        """Should return the last date with regular games before the All-Star event dates."""
+        raw = self._make_schedule(
+            game_dates=[
+                self._make_game_date("02/10/2026", ["", ""]),
+                self._make_game_date("02/12/2026", ["", ""]),  # last regular games
+                self._make_game_date("02/13/2026", ["Rising Stars Game"]),  # only excluded
+                self._make_game_date("02/15/2026", ["All-Star Game"]),  # only excluded
+                self._make_game_date("02/18/2026", ["", ""]),  # regular games resume
+            ],
+        )
+        assert nba_service._get_all_star_date_from_schedule(raw) == "2026-02-12"
+
+    def test_all_star_date_skips_excluded_only_dates(self, nba_service):
+        """Multiple consecutive excluded-only dates are all treated as part of the break."""
+        raw = self._make_schedule(
+            game_dates=[
+                self._make_game_date("02/12/2025", ["", ""]),
+                self._make_game_date("02/14/2025", ["Rising Stars Game"]),
+                self._make_game_date("02/15/2025", ["All-Star Celebrity Game"]),
+                self._make_game_date("02/16/2025", ["NBA All-Star Game"]),
+                self._make_game_date("02/18/2025", ["", ""]),
+            ],
+        )
+        assert nba_service._get_all_star_date_from_schedule(raw) == "2025-02-12"
+
+    def test_all_star_date_returns_none_when_no_all_star_events(self, nba_service):
+        """Returns None if no All-Star/Rising Stars labeled games appear."""
+        raw = self._make_schedule(
+            game_dates=[
+                self._make_game_date("10/22/2025", ["", ""]),
+                self._make_game_date("10/24/2025", ["", ""]),
+            ],
+        )
+        assert nba_service._get_all_star_date_from_schedule(raw) is None
+
+    def test_all_star_date_returns_none_on_empty_game_dates(self, nba_service):
+        raw = self._make_schedule(game_dates=[])
+        assert nba_service._get_all_star_date_from_schedule(raw) is None
+
+    def test_regular_season_end_date_extracted(self, nba_service):
+        from nba_wins_pool.types.nba_game_type import NBAGameType
+
+        season_type_dates = [
+            (
+                NBAGameType.PRESEASON,
+                datetime.fromisoformat("2025-10-01T07:00:00+00:00"),
+                datetime.fromisoformat("2025-10-21T06:59:00+00:00"),
+            ),
+            (
+                NBAGameType.REGULAR_SEASON,
+                datetime.fromisoformat("2025-10-21T07:00:00+00:00"),
+                datetime.fromisoformat("2026-04-13T06:59:00+00:00"),
+            ),
+            (
+                NBAGameType.PLAYOFFS,
+                datetime.fromisoformat("2026-04-18T07:00:00+00:00"),
+                datetime.fromisoformat("2026-06-27T06:59:00+00:00"),
+            ),
+        ]
+        assert nba_service._get_regular_season_end_date(season_type_dates) == "2026-04-13"
+
+    def test_regular_season_end_date_returns_none_when_absent(self, nba_service):
+        from nba_wins_pool.types.nba_game_type import NBAGameType
+
+        season_type_dates = [
+            (
+                NBAGameType.PLAYOFFS,
+                datetime.fromisoformat("2026-04-18T07:00:00+00:00"),
+                datetime.fromisoformat("2026-06-27T06:59:00+00:00"),
+            ),
+        ]
+        assert nba_service._get_regular_season_end_date(season_type_dates) is None
+
+    @pytest.mark.asyncio
+    async def test_get_season_milestones_returns_both(self, nba_service, mock_repo):
+        from unittest.mock import patch
+
+        from nba_wins_pool.models.external_data import DataFormat, ExternalData
+
+        espn_fixture = json.loads((FIXTURES_DIR / "sample-espn-nba-season.json").read_text())
+
+        raw_schedule = {
+            "leagueSchedule": {
+                "seasonYear": "2025-26",
+                "gameDates": [
+                    {"gameDate": "02/11/2026 00:00:00", "games": [{"gameLabel": "", "gameId": "g1"}]},
+                    {"gameDate": "02/12/2026 00:00:00", "games": [{"gameLabel": "", "gameId": "g2"}]},
+                    {"gameDate": "02/13/2026 00:00:00", "games": [{"gameLabel": "Rising Stars Game", "gameId": "g3"}]},
+                    {"gameDate": "02/15/2026 00:00:00", "games": [{"gameLabel": "All-Star Game", "gameId": "g4"}]},
+                    {"gameDate": "02/18/2026 00:00:00", "games": [{"gameLabel": "", "gameId": "g5"}]},
+                ],
+            }
+        }
+        cached = ExternalData(key="nba:schedule:2025-26", data_json=raw_schedule, data_format=DataFormat.JSON)
+        mock_repo.get_by_key.return_value = cached
+
+        with patch(
+            "nba_wins_pool.services.nba_data_service.requests.get",
+            return_value=_mock_requests_get(espn_fixture),
+        ):
+            nba_service.get_current_season.cache_clear()
+            with patch.object(nba_service, "get_current_season", return_value="2024-25"):
+                result = await nba_service.get_season_milestones("2025-26")
+
+        assert len(result) == 2
+        slugs = [m["slug"] for m in result]
+        assert "all_star_break" in slugs
+        assert "playoffs_start" in slugs
+        dates = [m["date"] for m in result]
+        assert dates == sorted(dates)
+        all_star = next(m for m in result if m["slug"] == "all_star_break")
+        assert all_star["date"] == "2026-02-12"  # last regular game date within All-Star week
+        playoffs = next(m for m in result if m["slug"] == "playoffs_start")
+        assert playoffs["date"] == "2026-04-13"
+
+    @pytest.mark.asyncio
+    async def test_get_season_milestones_empty_on_missing_season(self, nba_service):
+        result = await nba_service.get_season_milestones("")
+        # Empty season year causes ESPN fetch to fail; result should be an empty list or partial
+        # The key invariant: no exception is raised
+        assert isinstance(result, list)

--- a/backend/tests/test_wins_race_service.py
+++ b/backend/tests/test_wins_race_service.py
@@ -10,11 +10,12 @@ from nba_wins_pool.types.season_str import SeasonStr
 
 
 class FakeNbaDataService:
-    def __init__(self, scoreboard_data, schedule_data, scoreboard_date, season):
+    def __init__(self, scoreboard_data, schedule_data, scoreboard_date, season, milestones=None):
         self._scoreboard_data = scoreboard_data
         self._schedule_data = schedule_data
         self._scoreboard_date = scoreboard_date
         self._season = season
+        self._milestones = milestones or []
 
     async def get_scoreboard_cached(self):
         return self._scoreboard_data, self._scoreboard_date
@@ -29,6 +30,9 @@ class FakeNbaDataService:
 
     def get_current_season(self):
         return self._season
+
+    async def get_season_milestones(self, season_year):
+        return self._milestones
 
     async def get_game_data(self, season):
         # Combine schedule and scoreboard data
@@ -55,7 +59,7 @@ class FakeNbaDataService:
 
 
 @pytest.mark.asyncio
-async def test_wins_race_builds_timeseries(monkeypatch):
+async def test_wins_race_builds_timeseries():
     pool_id = uuid4()
     season = SeasonStr("2024-25")
 
@@ -116,20 +120,8 @@ async def test_wins_race_builds_timeseries(monkeypatch):
 
     fake_pool_season_service = FakePoolSeasonService()
 
-    # Mock SEASON_MILESTONES dictionary
-    test_milestones = {
-        "2024-25": [
-            {
-                "slug": "opening-night",
-                "date": "2024-10-24",
-                "description": "Opening Night",
-            }
-        ]
-    }
-    monkeypatch.setattr(
-        "nba_wins_pool.services.wins_race_service.SEASON_MILESTONES",
-        test_milestones,
-    )
+    test_milestones = [{"slug": "opening-night", "date": "2024-10-24", "description": "Opening Night"}]
+    fake_nba_service._milestones = test_milestones
 
     service = WinsRaceService(
         roster_repository=None,
@@ -150,11 +142,14 @@ async def test_wins_race_builds_timeseries(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_wins_race_returns_empty_when_no_games(monkeypatch):
+async def test_wins_race_returns_empty_when_no_games():
     pool_id = uuid4()
     season = SeasonStr("2024-25")
 
-    fake_nba_service = FakeNbaDataService([], [], scoreboard_date=pd.Timestamp("2024-10-16").date(), season=season)
+    test_milestones = [{"slug": "opening-night", "date": "2024-10-24", "description": "Opening Night"}]
+    fake_nba_service = FakeNbaDataService(
+        [], [], scoreboard_date=pd.Timestamp("2024-10-16").date(), season=season, milestones=test_milestones
+    )
 
     class FakePoolSeasonService:
         async def get_team_roster_mappings(self, **_: object):
@@ -172,13 +167,6 @@ async def test_wins_race_returns_empty_when_no_games(monkeypatch):
             return TeamRosterMappings(teams_df=teams_df, roster_names=["Roster A"])
 
     fake_pool_season_service = FakePoolSeasonService()
-
-    # Mock SEASON_MILESTONES dictionary
-    test_milestones = {"2024-25": [{"slug": "opening-night", "date": "2024-10-24", "description": "Opening Night"}]}
-    monkeypatch.setattr(
-        "nba_wins_pool.services.wins_race_service.SEASON_MILESTONES",
-        test_milestones,
-    )
 
     service = WinsRaceService(
         roster_repository=None,

--- a/frontend/src/components/pool/WinsRaceChart.vue
+++ b/frontend/src/components/pool/WinsRaceChart.vue
@@ -52,6 +52,10 @@ const updateChartData = () => {
   const metadata = props.winsRaceData.metadata
   const milestones = metadata?.milestones
 
+  const maxDateStr = rawData.reduce((max: string, d: any) => (d.date > max ? d.date : max), '')
+  const endTs = maxDateStr ? new Date(`${maxDateStr}T00:00:00`).getTime() : Date.now()
+  const startTs30d = endTs - 30 * 24 * 60 * 60 * 1000
+
   if (!milestones || !metadata?.rosters) return
 
   const dataset = [
@@ -99,7 +103,7 @@ const updateChartData = () => {
         position: 'insideStartTop',
       },
       data: milestones.map((milestone) => ({
-        xAxis: milestone.date,
+        xAxis: new Date(`${milestone.date}T00:00:00`).getTime(),
         name: milestone.description,
       })),
     },
@@ -113,9 +117,20 @@ const updateChartData = () => {
       backgroundColor: '',
       borderWidth: 0,
       textStyle: undefined,
-      order: 'valueDesc',
       trigger: 'axis',
       className: 'p-card',
+      formatter: (params: any) => {
+        if (!Array.isArray(params) || params.length === 0) return ''
+        const header = new Date(params[0].axisValue).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+        })
+        const lines = params
+          .filter((p: any) => p.value?.wins != null)
+          .sort((a: any, b: any) => b.value.wins - a.value.wins)
+          .map((p: any) => `${p.marker}${p.seriesName}: ${p.value.wins}`)
+        return [header, ...lines].join('<br/>')
+      },
     },
     legend: {
       icon: 'circle',
@@ -134,7 +149,7 @@ const updateChartData = () => {
     dataZoom: {
       type: 'slider',
       filterMode: 'weakFilter',
-      minSpan: 7,
+      minValueSpan: 7 * 24 * 60 * 60 * 1000,
       left: 'center',
       moveHandleSize: 15,
       labelFormatter: '',
@@ -163,7 +178,7 @@ const updateChartData = () => {
       },
     },
     xAxis: {
-      type: 'category',
+      type: 'time',
       axisLine: {
         show: false,
       },
@@ -172,9 +187,15 @@ const updateChartData = () => {
       },
       axisLabel: {
         margin: 10,
-        formatter: (value: string) => {
-          const date = new Date(`${value}T00:00:00`)
+        formatter: (value: number) => {
+          const date = new Date(value)
           return date.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
+        },
+      },
+      axisPointer: {
+        label: {
+          formatter: (params: any) =>
+            new Date(Number(params.value)).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
         },
       },
     },
@@ -195,8 +216,9 @@ const updateChartData = () => {
           },
           dataZoom: {
             throttle: 50,
-            startValue: 100,
-            minValueSpan: 14,
+            startValue: startTs30d,
+            endValue: endTs,
+            minValueSpan: 14 * 24 * 60 * 60 * 1000,
           },
           legend: {
             width: '75%',


### PR DESCRIPTION
Replaces the hardcoded `SEASON_MILESTONES` dict with milestones derived dynamically from existing data sources.

**All-Star Break** — walks `gameDates` from the NBA schedule looking for a consecutive run of dates containing only All-Star/Rising Stars labeled games, then returns the last date before that run with regular games. This avoids relying on the `weeks[]` array, which uses inconsistent names across seasons.

**Playoffs** — extracted from the ESPN Regular Season `endDate`, reusing the season type dates already fetched for game type classification.

Both milestones are computed in a new `NbaDataService.get_season_milestones()` method. Each source is wrapped in its own try/except so a failure in one doesn't suppress the other.

**Chart changes (WinsRaceChart.vue):**
- Switched `xAxis` from `category` to `time` so milestone lines render correctly on dates with no game data (e.g. All-Star weekend has no regular games in the category list)
- Added tooltip formatter to display date without hours/minutes
- Mobile dataZoom defaults to the last 30 days

Closes #120