### PR TITLE
fix: leaderboard today/yesterday cols, if_necessary parsing, season/tab date nav

### DIFF
--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -84,7 +84,7 @@ class LeaderboardService:
         # Handle empty games case
         scoreboard_date = None
         if not game_df.empty:
-            scoreboard_date = game_df["date_time"].max().date()
+            scoreboard_date = self.nba_data_service.get_scoreboard_date(season)
 
         if season == current_season:
             (

--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -411,7 +411,8 @@ class NbaDataService:
         game_label = game.get("gameLabel") or None
         series_game_text = game.get("info") or game.get("gameSubLabel") or None
         series_status_text = game.get("subInfo") or game.get("seriesText") or None
-        if_necessary = bool(game.get("ifNecessary", False))
+        raw_if_necessary = game.get("ifNecessary", False)
+        if_necessary = raw_if_necessary is True or str(raw_if_necessary).lower() == "true"
 
         return {
             "date_time": game_timestamp,

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -525,6 +525,46 @@ class TestPlayoffInfo:
         assert orl_det["away_seed"] == 1
 
 
+class TestParseSchedule:
+    """Tests for _parse_schedule using real fixture data."""
+
+    @pytest.fixture
+    def schedule_fixture(self):
+        with open(FIXTURES_DIR / "sample-nba-schedule-response.json") as f:
+            return json.load(f)
+
+    @pytest.fixture
+    def schedule_2022_fixture(self):
+        with open(FIXTURES_DIR / "sample-nba-schedule-2022-response.json") as f:
+            return json.load(f)
+
+    def test_parses_games_from_current_fixture(self, nba_service, schedule_fixture):
+        games = nba_service._parse_schedule(schedule_fixture)
+        assert len(games) > 0
+
+    def test_parses_games_from_2022_fixture(self, nba_service, schedule_2022_fixture):
+        games = nba_service._parse_schedule(schedule_2022_fixture)
+        assert len(games) > 0
+
+    def test_if_necessary_string_false_parsed_as_bool_false(self, nba_service, schedule_2022_fixture):
+        """2022 fixture stores ifNecessary as the string "false"; must not be truthy."""
+        games = nba_service._parse_schedule(schedule_2022_fixture)
+        assert all(g["if_necessary"] is False for g in games)
+
+    def test_if_necessary_false_in_current_fixture(self, nba_service, schedule_fixture):
+        games = nba_service._parse_schedule(schedule_fixture)
+        assert all(g["if_necessary"] is False for g in games if g.get("if_necessary") is not None)
+
+    def test_all_2022_games_are_final(self, nba_service, schedule_2022_fixture):
+        games = nba_service._parse_schedule(schedule_2022_fixture)
+        assert all(g["status"] == NBAGameStatus.FINAL for g in games)
+
+    def test_game_fields_present(self, nba_service, schedule_2022_fixture):
+        games = nba_service._parse_schedule(schedule_2022_fixture)
+        required = {"game_id", "date_time", "home_team", "away_team", "status", "if_necessary"}
+        assert required.issubset(games[0].keys())
+
+
 class TestGameUrl:
     """game_url is populated from shareUrl (gamecardfeed) or constructed from teamSlugs (schedule)."""
 

--- a/frontend/src/composables/useTodayGames.ts
+++ b/frontend/src/composables/useTodayGames.ts
@@ -18,10 +18,24 @@ export function useTodayGames() {
       const res = await fetch(url)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()
-      games.value = data.games
-      gamesDate.value = data.date
-      scoreboardDate.value = data.scoreboard_date
       if (data.game_dates?.length) gameDates.value = data.game_dates
+      // If no explicit date was requested and the returned date has no games in this season,
+      // default to the last available game date.
+      if (!date && data.game_dates?.length && !data.game_dates.includes(data.date)) {
+        const lastDate = data.game_dates[data.game_dates.length - 1]
+        const res2 = await fetch(
+          `/api/pools/${encodeURIComponent(poolId)}/season/${encodeURIComponent(season)}/today-games?date=${encodeURIComponent(lastDate)}`,
+        )
+        if (!res2.ok) throw new Error(`HTTP ${res2.status}`)
+        const data2 = await res2.json()
+        games.value = data2.games
+        gamesDate.value = data2.date
+        scoreboardDate.value = data2.scoreboard_date
+      } else {
+        games.value = data.games
+        gamesDate.value = data.date
+        scoreboardDate.value = data.scoreboard_date
+      }
     } catch (e: any) {
       console.error('Error fetching games:', e)
       error.value = e?.message || 'Failed to fetch games'

--- a/frontend/src/views/PoolSeasonOverview.vue
+++ b/frontend/src/views/PoolSeasonOverview.vue
@@ -154,9 +154,9 @@ type Tab = (typeof TAB_VALUES)[number]
 const routeTab = route.query.tab
 const activeTab = ref<Tab>(TAB_VALUES.includes(routeTab as Tab) ? (routeTab as Tab) : 'standings')
 function buildQuery(overrides: Record<string, string | undefined>) {
-  const { tab: _t, date: _d, ...rest } = route.query as Record<string, string>
-  const { tab, date } = { tab: _t, date: _d, ...overrides }
-  return { ...rest, ...(tab ? { tab } : {}), ...(date ? { date } : {}) }
+  const { tab: _t, ...rest } = route.query as Record<string, string>
+  const { tab } = { tab: _t, ...overrides }
+  return { ...rest, ...(tab ? { tab } : {}) }
 }
 
 watch(activeTab, (tab) => {
@@ -528,16 +528,13 @@ onMounted(() => {
   resolvePoolAndSlug()
 })
 
-watch(todayGamesDate, (date) => {
-  router.replace({ query: buildQuery({ date: date ?? undefined }) })
-})
 
 watch(
   [() => pool.value?.id, () => season.value],
   ([id, s]) => {
     if (id) {
       fetchLeaderboard(id, s as string)
-      fetchTodayGames(id, s as string, (route.query.date as string) || undefined)
+      fetchTodayGames(id, s as string)
       fetchPoolSeasonOverview({ poolId: id, season: s as string })
       fetchAuctions({ pool_id: id })
       fetchRosters({ pool_id: id, season: s as string })
@@ -889,7 +886,7 @@ async function loadPoolSeasons(poolId: string) {
             <li v-for="s in poolSeasons" :key="s.id">
               <RouterLink
                 v-if="s.season !== season"
-                :to="{ name: 'pool-season', params: { slug: pool?.slug, season: s.season } }"
+                :to="{ name: 'pool-season', params: { slug: pool?.slug, season: s.season }, query: { tab: route.query.tab } }"
                 class="flex items-center gap-2 hover:opacity-75"
               >
                 <p>{{ s.season }}</p>


### PR DESCRIPTION
## Summary

- **Leaderboard today/yesterday columns broken**: `scoreboard_date` was computed as `game_df["date_time"].max().date()`, which returned a future end-of-season date after the schedule parser stopped filtering by scoreboard date in #128 — fixed to use `nba_data_service.get_scoreboard_date()`
- **`if_necessary` always true for historical seasons**: The schedule CDN sends `"ifNecessary": "false"` as a string; `bool("false")` is `True` in Python — fixed to check for actual boolean/string `"true"`
- **Games tab date navigation on season switch**: When switching to a historical season, the scoreboard date falls outside that season's game dates; now auto-fetches the last available game date
- **Remove date URL query param**: No longer needed; also clears on tab/season switch

## Test plan

- [ ] Leaderboard today/yesterday columns show correct records for today's games
- [ ] Historical seasons (e.g. 2021-22) no longer show "if necessary" on all games
- [ ] Switching to a historical season on the Games tab defaults to the last game date
- [ ] No `?date=` param appears in the URL when navigating the Games tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)