### PR TITLE
fix: hide win probability bar in Q4 when moneyline odds are suspended

### DIFF
--- a/backend/src/nba_wins_pool/services/leaderboard_service.py
+++ b/backend/src/nba_wins_pool/services/leaderboard_service.py
@@ -423,6 +423,8 @@ class LeaderboardService:
             home_id = safe_int(game["home_team"])
             away_id = safe_int(game["away_team"])
             odds = odds_map.get(safe_str(game.get("game_code")))
+            period = safe_int(game.get("period")) or 0
+            odds_suspended = odds is not None and odds.get("both_suspended") and period >= 4
             result.append(
                 {
                     "game_id": game["game_id"],
@@ -444,8 +446,8 @@ class LeaderboardService:
                     "if_necessary": bool(game.get("if_necessary", False)),
                     "home_seed": safe_int(game.get("home_seed")),
                     "away_seed": safe_int(game.get("away_seed")),
-                    "home_win_pct": odds["home"] if odds else None,
-                    "away_win_pct": odds["away"] if odds else None,
+                    "home_win_pct": odds["home"] if odds and not odds_suspended else None,
+                    "away_win_pct": odds["away"] if odds and not odds_suspended else None,
                     **self._build_game_side("home", game, home_id, teams_df, roster_season_wins, today_roster_record),
                     **self._build_game_side("away", game, away_id, teams_df, roster_season_wins, today_roster_record),
                 }

--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -434,6 +434,7 @@ class NbaDataService:
             "if_necessary": if_necessary,
             "status_text": game.get("gameStatusText"),
             "game_clock": game.get("gameClock"),
+            "period": game.get("period", 0),
             "status": status,
             "game_type": game_type,
             "arena_name": game.get("arenaName"),
@@ -563,6 +564,7 @@ class NbaDataService:
         "status",
         "status_text",
         "game_clock",
+        "period",
         "home_score",
         "away_score",
         "game_url",
@@ -698,7 +700,12 @@ class NbaDataService:
             logger.warning("Failed to fetch sportsbook game win probabilities", exc_info=True)
             return {}
         return {
-            row["gamecode"]: {"home": row["home_win_prob"], "away": row["away_win_prob"]} for _, row in df.iterrows()
+            row["gamecode"]: {
+                "home": row["home_win_prob"],
+                "away": row["away_win_prob"],
+                "both_suspended": bool(row.get("both_suspended", False)),
+            }
+            for _, row in df.iterrows()
         }
 
     NBA_BRACKET_URL_TEMPLATE = "https://cdn.nba.com/static/json/staticData/brackets/{year}/{bracket}.json"

--- a/backend/src/nba_wins_pool/services/nba_vegas_projections_service.py
+++ b/backend/src/nba_wins_pool/services/nba_vegas_projections_service.py
@@ -530,6 +530,10 @@ class NBAVegasProjectionsService:
             if not home_tricode or not away_tricode:
                 continue
 
+            both_suspended = (
+                home_runner.get("runnerStatus") == "SUSPENDED" and away_runner.get("runnerStatus") == "SUSPENDED"
+            )
+
             home_odds = home_runner["winRunnerOdds"]["americanDisplayOdds"]["americanOddsInt"]
             away_odds = away_runner["winRunnerOdds"]["americanDisplayOdds"]["americanOddsInt"]
 
@@ -553,11 +557,21 @@ class NBAVegasProjectionsService:
                     "home_tricode": home_tricode,
                     "away_win_prob": away_raw / total,
                     "home_win_prob": home_raw / total,
+                    "both_suspended": both_suspended,
                 }
             )
 
         return pd.DataFrame(
-            rows, columns=["game_date", "gamecode", "away_tricode", "home_tricode", "away_win_prob", "home_win_prob"]
+            rows,
+            columns=[
+                "game_date",
+                "gamecode",
+                "away_tricode",
+                "home_tricode",
+                "away_win_prob",
+                "home_win_prob",
+                "both_suspended",
+            ],
         )
 
     async def write_projections(self):


### PR DESCRIPTION
## Summary
- Detects when both FanDuel moneyline runners have `runnerStatus == "SUSPENDED"` and tracks this per game
- Adds `period` to the game data pipeline (`_parse_game_data` → `LIVE_OVERLAY_COLS` → leaderboard response) so Q4 can be detected server-side
- Suppresses `home_win_pct`/`away_win_pct` in the leaderboard response when `period >= 4` and both odds are suspended — the existing frontend `v-if` then naturally hides the bar

## Test plan
- [ ] Verify the bar shows normally during Q1–Q3 even if odds are briefly suspended
- [ ] Verify the bar disappears once both runners are suspended in Q4
- [ ] Confirm all existing leaderboard tests pass (`cd backend && uv run pytest tests/test_leaderboard_service.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)