### PR TITLE
feat: precompute win probability bar colors on the backend

### DIFF
--- a/backend/src/nba_wins_pool/data/nba-team-details.json
+++ b/backend/src/nba_wins_pool/data/nba-team-details.json
@@ -1,0 +1,510 @@
+{
+  "atl": {
+    "teamId": 1610612737,
+    "teamCity": "Atlanta",
+    "teamName": "Hawks",
+    "alternateTeamName": "Hawks",
+    "conference": "East",
+    "division": "Southeast",
+    "colors": {
+      "primaryLight": "#C8102E",
+      "primaryDark": "#C8102E",
+      "secondaryLight": "#FDB927",
+      "secondaryDark": "#FDB927",
+      "tertiaryLight": "#000000",
+      "tertiaryDark": "#000000"
+    }
+  },
+  "bkn": {
+    "teamId": 1610612751,
+    "teamCity": "Brooklyn",
+    "teamName": "Nets",
+    "alternateTeamName": "Nets",
+    "conference": "East",
+    "division": "Atlantic",
+    "colors": {
+      "primaryLight": "#000000",
+      "primaryDark": "#707271",
+      "secondaryLight": "#707271",
+      "secondaryDark": "#000000",
+      "tertiaryLight": null,
+      "tertiaryDark": null
+    }
+  },
+  "bos": {
+    "teamId": 1610612738,
+    "teamCity": "Boston",
+    "teamName": "Celtics",
+    "alternateTeamName": "Celtics",
+    "conference": "East",
+    "division": "Atlantic",
+    "colors": {
+      "primaryLight": "#008348",
+      "primaryDark": "#008348",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": "#BB9753",
+      "tertiaryDark": "#BB9753"
+    }
+  },
+  "cha": {
+    "teamId": 1610612766,
+    "teamCity": "Charlotte",
+    "teamName": "Hornets",
+    "alternateTeamName": "Hornets",
+    "conference": "East",
+    "division": "Southeast",
+    "colors": {
+      "primaryLight": "#00788C",
+      "primaryDark": "#00788C",
+      "secondaryLight": "#1D1160",
+      "secondaryDark": "#1D1160",
+      "tertiaryLight": "#A1A1A4",
+      "tertiaryDark": "#A1A1A4"
+    }
+  },
+  "chi": {
+    "teamId": 1610612741,
+    "teamCity": "Chicago",
+    "teamName": "Bulls",
+    "alternateTeamName": "Bulls",
+    "conference": "East",
+    "division": "Central",
+    "colors": {
+      "primaryLight": "#CE1141",
+      "primaryDark": "#CE1141",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": null,
+      "tertiaryDark": null
+    }
+  },
+  "cle": {
+    "teamId": 1610612739,
+    "teamCity": "Cleveland",
+    "teamName": "Cavaliers",
+    "alternateTeamName": "Cavaliers",
+    "conference": "East",
+    "division": "Central",
+    "colors": {
+      "primaryLight": "#6F263D",
+      "primaryDark": "#6F263D",
+      "secondaryLight": "#FFB81C",
+      "secondaryDark": "#FFB81C",
+      "tertiaryLight": "#041E42",
+      "tertiaryDark": "#041E42"
+    }
+  },
+  "dal": {
+    "teamId": 1610612742,
+    "teamCity": "Dallas",
+    "teamName": "Mavericks",
+    "alternateTeamName": "Mavericks",
+    "conference": "West",
+    "division": "Southwest",
+    "colors": {
+      "primaryLight": "#0064B1",
+      "primaryDark": "#0064B1",
+      "secondaryLight": "#00285E",
+      "secondaryDark": "#00285E",
+      "tertiaryLight": "#BBC4CA",
+      "tertiaryDark": "#BBC4CA"
+    }
+  },
+  "den": {
+    "teamId": 1610612743,
+    "teamCity": "Denver",
+    "teamName": "Nuggets",
+    "alternateTeamName": "Nuggets",
+    "conference": "West",
+    "division": "Northwest",
+    "colors": {
+      "primaryLight": "#0E2240",
+      "primaryDark": "#0E2240",
+      "secondaryLight": "#FEC524",
+      "secondaryDark": "#FEC524",
+      "tertiaryLight": "#8B2131",
+      "tertiaryDark": "#8B2131"
+    }
+  },
+  "det": {
+    "teamId": 1610612765,
+    "teamCity": "Detroit",
+    "teamName": "Pistons",
+    "alternateTeamName": "Pistons",
+    "conference": "East",
+    "division": "Central",
+    "colors": {
+      "primaryLight": "#1D428A",
+      "primaryDark": "#1D428A",
+      "secondaryLight": "#C8102E",
+      "secondaryDark": "#C8102E",
+      "tertiaryLight": "#BEC0C2",
+      "tertiaryDark": "#BEC0C2"
+    }
+  },
+  "gsw": {
+    "teamId": 1610612744,
+    "teamCity": "Golden State",
+    "teamName": "Warriors",
+    "alternateTeamName": "Warriors",
+    "conference": "West",
+    "division": "Pacific",
+    "colors": {
+      "primaryLight": "#1D428A",
+      "primaryDark": "#1D428A",
+      "secondaryLight": "#FDB927",
+      "secondaryDark": "#FDB927",
+      "tertiaryLight": null,
+      "tertiaryDark": null
+    }
+  },
+  "hou": {
+    "teamId": 1610612745,
+    "teamCity": "Houston",
+    "teamName": "Rockets",
+    "alternateTeamName": "Rockets",
+    "conference": "West",
+    "division": "Southwest",
+    "colors": {
+      "primaryLight": "#CE1141",
+      "primaryDark": "#CE1141",
+      "secondaryLight": "#9EA2A2",
+      "secondaryDark": "#9EA2A2",
+      "tertiaryLight": "#000000",
+      "tertiaryDark": "#000000"
+    }
+  },
+  "ind": {
+    "teamId": 1610612754,
+    "teamCity": "Indiana",
+    "teamName": "Pacers",
+    "alternateTeamName": "Pacers",
+    "conference": "East",
+    "division": "Central",
+    "colors": {
+      "primaryLight": "#002D62",
+      "primaryDark": "#002D62",
+      "secondaryLight": "#FDBB30",
+      "secondaryDark": "#FDBB30",
+      "tertiaryLight": "#BEC0C2",
+      "tertiaryDark": "#BEC0C2"
+    }
+  },
+  "lac": {
+    "teamId": 1610612746,
+    "teamCity": "LA",
+    "teamName": "Clippers",
+    "alternateTeamName": "Clippers",
+    "conference": "West",
+    "division": "Pacific",
+    "colors": {
+      "primaryLight": "#12173F",
+      "primaryDark": "#12173F",
+      "secondaryLight": "#C8012E",
+      "secondaryDark": "#C8012E",
+      "tertiaryLight": "#4891CE",
+      "tertiaryDark": "#4891CE"
+    }
+  },
+  "lal": {
+    "teamId": 1610612747,
+    "teamCity": "Los Angeles",
+    "teamName": "Lakers",
+    "alternateTeamName": "Lakers",
+    "conference": "West",
+    "division": "Pacific",
+    "colors": {
+      "primaryLight": "#552583",
+      "primaryDark": "#FDB927",
+      "secondaryLight": "#FDB927",
+      "secondaryDark": "#552583",
+      "tertiaryLight": "#000000",
+      "tertiaryDark": "#000000"
+    }
+  },
+  "mem": {
+    "teamId": 1610612763,
+    "teamCity": "Memphis",
+    "teamName": "Grizzlies",
+    "alternateTeamName": "Grizzlies",
+    "conference": "West",
+    "division": "Southwest",
+    "colors": {
+      "primaryLight": "#5D76A9",
+      "primaryDark": "#5D76A9",
+      "secondaryLight": "#12173F",
+      "secondaryDark": "#12173F",
+      "tertiaryLight": "#707271",
+      "tertiaryDark": "#707271"
+    }
+  },
+  "mia": {
+    "teamId": 1610612748,
+    "teamCity": "Miami",
+    "teamName": "Heat",
+    "alternateTeamName": "Heat",
+    "conference": "East",
+    "division": "Southeast",
+    "colors": {
+      "primaryLight": "#98002E",
+      "primaryDark": "#98002E",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": "#F9A01B",
+      "tertiaryDark": "#F9A01B"
+    }
+  },
+  "mil": {
+    "teamId": 1610612749,
+    "teamCity": "Milwaukee",
+    "teamName": "Bucks",
+    "alternateTeamName": "Bucks",
+    "conference": "East",
+    "division": "Central",
+    "colors": {
+      "primaryLight": "#00471B",
+      "primaryDark": "#00471B",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": "#0077C0",
+      "tertiaryDark": "#0077C0"
+    }
+  },
+  "min": {
+    "teamId": 1610612750,
+    "teamCity": "Minnesota",
+    "teamName": "Timberwolves",
+    "alternateTeamName": "Timberwolves",
+    "conference": "West",
+    "division": "Northwest",
+    "colors": {
+      "primaryLight": "#0C2340",
+      "primaryDark": "#236192",
+      "secondaryLight": "#236192",
+      "secondaryDark": "#0C2340",
+      "tertiaryLight": "#78BE20",
+      "tertiaryDark": "#78BE20"
+    }
+  },
+  "nop": {
+    "teamId": 1610612740,
+    "teamCity": "New Orleans",
+    "teamName": "Pelicans",
+    "localAccessName": "Pelicans+",
+    "localAccessShortName": "Pelicans+",
+    "alternateTeamName": "Pelicans",
+    "conference": "West",
+    "division": "Southwest",
+    "localAccessUpsellOverride": {
+      "mobile": {
+        "descriptionKey": "PelicansLocalAccessUpsell"
+      },
+      "ced": {
+        "descriptionKey": "PelicansLocalAccessUpsell"
+      },
+      "web": {
+        "message": "Stream live Pelicans games with Pelicans+. Replays are not available.",
+        "buttonUrl": "https://www.nba.com/watch/league-pass-stream/pelicans"
+      }
+    },
+    "colors": {
+      "primaryLight": "#0A2240",
+      "primaryDark": "#0A2240",
+      "secondaryLight": "#8C734B",
+      "secondaryDark": "#8C734B",
+      "tertiaryLight": "#CE0E2D",
+      "tertiaryDark": "#CE0E2D"
+    }
+  },
+  "nyk": {
+    "teamId": 1610612752,
+    "teamCity": "New York",
+    "teamName": "Knicks",
+    "alternateTeamName": "Knicks",
+    "conference": "East",
+    "division": "Atlantic",
+    "colors": {
+      "primaryLight": "#1D428A",
+      "primaryDark": "#1D428A",
+      "secondaryLight": "#F58426",
+      "secondaryDark": "#F58426",
+      "tertiaryLight": "#BEC0C2",
+      "tertiaryDark": "#BEC0C2"
+    }
+  },
+  "okc": {
+    "teamId": 1610612760,
+    "teamCity": "Oklahoma City",
+    "teamName": "Thunder",
+    "alternateTeamName": "Thunder",
+    "conference": "West",
+    "division": "Northwest",
+    "colors": {
+      "primaryLight": "#007AC1",
+      "primaryDark": "#007AC1",
+      "secondaryLight": "#EF3B24",
+      "secondaryDark": "#EF3B24",
+      "tertiaryLight": "#002D62",
+      "tertiaryDark": "#002D62"
+    }
+  },
+  "orl": {
+    "teamId": 1610612753,
+    "teamCity": "Orlando",
+    "teamName": "Magic",
+    "alternateTeamName": "Magic",
+    "conference": "East",
+    "division": "Southeast",
+    "colors": {
+      "primaryLight": "#0050B5",
+      "primaryDark": "#0050B5",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": "#C4CED4",
+      "tertiaryDark": "#C4CED4"
+    }
+  },
+  "phi": {
+    "teamId": 1610612755,
+    "teamCity": "Philadelphia",
+    "teamName": "76ers",
+    "alternateTeamName": "76ers",
+    "conference": "East",
+    "division": "Atlantic",
+    "colors": {
+      "primaryLight": "#1D428A",
+      "primaryDark": "#1D428A",
+      "secondaryLight": "#ED174C",
+      "secondaryDark": "#ED174C",
+      "tertiaryLight": "#002B5C",
+      "tertiaryDark": "#002B5C"
+    }
+  },
+  "phx": {
+    "teamId": 1610612756,
+    "teamCity": "Phoenix",
+    "teamName": "Suns",
+    "alternateTeamName": "Suns",
+    "conference": "West",
+    "division": "Pacific",
+    "colors": {
+      "primaryLight": "#1D1160",
+      "primaryDark": "#E56020",
+      "secondaryLight": "#E56020",
+      "secondaryDark": "#1D1160",
+      "tertiaryLight": "#000000",
+      "tertiaryDark": "#000000"
+    }
+  },
+  "por": {
+    "teamId": 1610612757,
+    "teamCity": "Portland",
+    "teamName": "Trail Blazers",
+    "alternateTeamName": "Trail Blazers",
+    "conference": "West",
+    "division": "Northwest",
+    "colors": {
+      "primaryLight": "#E03A3E",
+      "primaryDark": "#E03A3E",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": null,
+      "tertiaryDark": null
+    }
+  },
+  "sac": {
+    "teamId": 1610612758,
+    "teamCity": "Sacramento",
+    "teamName": "Kings",
+    "alternateTeamName": "Kings",
+    "conference": "West",
+    "division": "Pacific",
+    "colors": {
+      "primaryLight": "#5A2D81",
+      "primaryDark": "#5A2D81",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": "#63727A",
+      "tertiaryDark": "#63727A"
+    }
+  },
+  "sas": {
+    "teamId": 1610612759,
+    "teamCity": "San Antonio",
+    "teamName": "Spurs",
+    "alternateTeamName": "Spurs",
+    "conference": "West",
+    "division": "Southwest",
+    "colors": {
+      "primaryLight": "#000000",
+      "primaryDark": "#C4CED4",
+      "secondaryLight": "#C4CED4",
+      "secondaryDark": "#000000",
+      "tertiaryLight": null,
+      "tertiaryDark": null
+    }
+  },
+  "tor": {
+    "teamId": 1610612761,
+    "teamCity": "Toronto",
+    "teamName": "Raptors",
+    "alternateTeamName": "Raptors",
+    "conference": "East",
+    "division": "Atlantic",
+    "colors": {
+      "primaryLight": "#CE1141",
+      "primaryDark": "#CE1141",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": "#393A96",
+      "tertiaryDark": "#393A96"
+    }
+  },
+  "uta": {
+    "teamId": 1610612762,
+    "teamCity": "Utah",
+    "teamName": "Jazz",
+    "localAccessName": "Jazz+",
+    "localAccessShortName": "Jazz+",
+    "alternateTeamName": "Jazz",
+    "conference": "West",
+    "division": "Northwest",
+    "localAccessUpsellOverride": {
+      "mobile": {
+        "descriptionKey": "JazzLocalAccessUpsell"
+      },
+      "ced": {
+        "descriptionKey": "JazzLocalAccessUpsell"
+      },
+      "web": {
+        "message": "Activate Jazz+ to watch locally broadcast games live and on-demand.",
+        "buttonUrl": "http://utahjazzplus.com/"
+      }
+    },
+    "colors": {
+      "primaryLight": "#4E008E",
+      "primaryDark": "#4E008E",
+      "secondaryLight": "#000000",
+      "secondaryDark": "#000000",
+      "tertiaryLight": "#79A3DC",
+      "tertiaryDark": "#79A3DC"
+    }
+  },
+  "was": {
+    "teamId": 1610612764,
+    "teamCity": "Washington",
+    "teamName": "Wizards",
+    "alternateTeamName": "Wizards",
+    "conference": "East",
+    "division": "Southeast",
+    "colors": {
+      "primaryLight": "#002B5C",
+      "primaryDark": "#E31837",
+      "secondaryLight": "#E31837",
+      "secondaryDark": "#002B5C",
+      "tertiaryLight": "#C4CED4",
+      "tertiaryDark": "#C4CED4"
+    }
+  }
+}

--- a/backend/src/nba_wins_pool/main_backend.py
+++ b/backend/src/nba_wins_pool/main_backend.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .routes import app_router
 from .services.scheduler_service import get_scheduler
+from .services.team_colors_service import build_matchup_colors
 from .utils.error import detailed_error_handler
 from .utils.spa_static_files import SinglePageApplication
 
@@ -25,6 +26,7 @@ async def lifespan(app: FastAPI):
     """Manage application lifecycle events."""
     # Startup
     logger.info("Starting up application...")
+    build_matchup_colors()
     scheduler = get_scheduler()
     await scheduler.start()
     logger.info("Application startup complete")

--- a/backend/src/nba_wins_pool/routes/__init__.py
+++ b/backend/src/nba_wins_pool/routes/__init__.py
@@ -11,6 +11,7 @@ from .pools import router as pools_router
 from .roster_slots import router as roster_slots_router
 from .rosters import router as rosters_router
 from .sse import router as sse_router
+from .team_colors import router as team_colors_router
 from .teams import router as teams_router
 
 # register routers here
@@ -24,6 +25,7 @@ api_router.include_router(auction_lots_router)
 api_router.include_router(auction_bids_router)
 api_router.include_router(roster_slots_router)
 api_router.include_router(teams_router)
+api_router.include_router(team_colors_router)
 
 internal_router = APIRouter(prefix="/internal", tags=["internal"])
 internal_router.include_router(health_router)

--- a/backend/src/nba_wins_pool/routes/team_colors.py
+++ b/backend/src/nba_wins_pool/routes/team_colors.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+from ..services.team_colors_service import get_matchup_colors, get_matchup_colors_debug
+
+router = APIRouter(tags=["team-colors"])
+
+
+@router.get("/team-colors")
+def get_team_colors() -> dict[str, dict[str, dict[str, str]]]:
+    return get_matchup_colors()
+
+
+@router.get("/team-colors/debug")
+def get_team_colors_debug() -> dict[str, dict[str, dict[str, str]]]:
+    return get_matchup_colors_debug()

--- a/backend/src/nba_wins_pool/services/team_colors_service.py
+++ b/backend/src/nba_wins_pool/services/team_colors_service.py
@@ -1,0 +1,141 @@
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DATA_PATH = Path(__file__).parent.parent / "data" / "nba-team-details.json"
+
+_MIN_LUMINANCE = 0.05  # filters colors too dark to see on a dark background
+_MIN_HUE_DIFF = 30.0  # degrees; primary distinguishability criterion
+_MIN_SATURATION = 0.15  # below this, hue is meaningless (grays/near-whites)
+_MIN_GRAY_CONTRAST = 1.5  # luminance contrast fallback only when both colors are unsaturated
+_FALLBACK_COLOR = "#6b7280"
+
+
+def _relative_luminance(hex_color: str) -> float:
+    h = hex_color.lstrip("#")
+    r, g, b = (int(h[i : i + 2], 16) / 255 for i in (0, 2, 4))
+
+    def lin(c: float) -> float:
+        return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+
+
+def _hue(hex_color: str) -> tuple[float, float]:
+    """Return (hue_degrees, saturation) in HSL space."""
+    h = hex_color.lstrip("#")
+    r, g, b = (int(h[i : i + 2], 16) / 255 for i in (0, 2, 4))
+    max_c, min_c = max(r, g, b), min(r, g, b)
+    d = max_c - min_c
+    lightness = (max_c + min_c) / 2
+    if d == 0:
+        return 0.0, 0.0
+    saturation = d / (2 - max_c - min_c) if lightness > 0.5 else d / (max_c + min_c)
+    if max_c == r:
+        hue = (g - b) / d % 6
+    elif max_c == g:
+        hue = (b - r) / d + 2
+    else:
+        hue = (r - g) / d + 4
+    return hue * 60, saturation
+
+
+def _distinguishable(hex1: str, hex2: str) -> bool:
+    """Two colors are distinguishable if they differ enough in hue.
+
+    Luminance contrast is only used as a fallback when both colors are unsaturated
+    (grays), where hue is meaningless.
+    """
+    h1, s1 = _hue(hex1)
+    h2, s2 = _hue(hex2)
+    both_unsaturated = s1 < _MIN_SATURATION and s2 < _MIN_SATURATION
+    if both_unsaturated:
+        l1, l2 = _relative_luminance(hex1), _relative_luminance(hex2)
+        return (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05) >= _MIN_GRAY_CONTRAST
+    # One or both colors are saturated — hue difference is the decider.
+    # A saturated color paired with a gray is always distinguishable.
+    if s1 < _MIN_SATURATION or s2 < _MIN_SATURATION:
+        return True
+    return min(abs(h1 - h2), 360 - abs(h1 - h2)) >= _MIN_HUE_DIFF
+
+
+_CANDIDATE_LABELS = ["primary", "secondary", "tertiary"]
+
+
+def _candidate_colors(colors: dict) -> list[tuple[str, str]]:
+    """Return (color, label) pairs that pass the minimum luminance threshold."""
+    candidates = []
+    for label, key in zip(_CANDIDATE_LABELS, ["primaryDark", "secondaryDark", "tertiaryDark"]):
+        c = colors.get(key)
+        if c and _relative_luminance(c) >= _MIN_LUMINANCE:
+            candidates.append((c, label))
+    return candidates or [(_FALLBACK_COLOR, "fallback")]
+
+
+def _best_pair(away: list[tuple[str, str]], home: list[tuple[str, str]]) -> tuple[str, str, str, str]:
+    """Return (away_color, away_label, home_color, home_label).
+
+    Pairs are tried by increasing depth (sum of candidate indices) so that changing just
+    one team's color is always preferred over changing both.
+    """
+    for depth in range(len(away) + len(home) - 1):
+        for i in range(depth + 1):
+            j = depth - i
+            if i >= len(away) or j >= len(home):
+                continue
+            ac, al = away[i]
+            hc, hl = home[j]
+            if _distinguishable(ac, hc):
+                return ac, al, hc, hl
+    # Nothing distinguishable by hue — best luminance contrast as last resort
+    best_contrast = 0.0
+    result = (*away[0], *home[0])
+    for ac, al in away:
+        for hc, hl in home:
+            l1, l2 = _relative_luminance(ac), _relative_luminance(hc)
+            c = (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05)
+            if c > best_contrast:
+                best_contrast = c
+                result = (ac, al, hc, hl)
+    return result
+
+
+# {away_tricode: {home_tricode: {"away": color, "home": color}}}
+_matchup_colors: dict[str, dict[str, dict[str, str]]] = {}
+# Same structure but includes label metadata for inspection
+_matchup_colors_debug: dict[str, dict[str, dict[str, str]]] = {}
+
+
+def build_matchup_colors() -> None:
+    """Precompute bar colors for every possible matchup. Called once at startup."""
+    with open(_DATA_PATH) as f:
+        team_details = json.load(f)
+
+    candidates: dict[str, list[tuple[str, str]]] = {
+        abbr.upper(): _candidate_colors(details["colors"]) for abbr, details in team_details.items()
+    }
+
+    for away_tricode, away_candidates in candidates.items():
+        _matchup_colors[away_tricode] = {}
+        _matchup_colors_debug[away_tricode] = {}
+        for home_tricode, home_candidates in candidates.items():
+            ac, al, hc, hl = _best_pair(away_candidates, home_candidates)
+            _matchup_colors[away_tricode][home_tricode] = {"away": ac, "home": hc}
+            _matchup_colors_debug[away_tricode][home_tricode] = {
+                "away": ac,
+                "away_label": al,
+                "home": hc,
+                "home_label": hl,
+            }
+
+    logger.info("Precomputed team color pairings for %d teams (%d matchups)", len(candidates), len(candidates) ** 2)
+
+
+def get_matchup_colors() -> dict[str, dict[str, dict[str, str]]]:
+    return _matchup_colors
+
+
+def get_matchup_colors_debug() -> dict[str, dict[str, dict[str, str]]]:
+    return _matchup_colors_debug

--- a/frontend/src/components/pool/TodayGames.vue
+++ b/frontend/src/components/pool/TodayGames.vue
@@ -1,50 +1,13 @@
 <script setup lang="ts">
 import { formatUTCTime } from '../../utils/time'
 import type { TodayGame } from '../../types/leaderboard'
+import { useTeamColors } from '../../composables/useTeamColors'
 
 const props = defineProps<{
   games: TodayGame[]
 }>()
 
-// Primary colors sourced from each team's logo SVG.
-// For teams whose logo primary is too dark on a dark background,
-// the secondary accent color (usually gold, teal, or lime) is used instead.
-const TEAM_COLORS: Record<string, string> = {
-  ATL: '#E03A3E',  // Hawks red
-  BOS: '#007A33',  // Celtics green
-  BKN: '#BBBBBB',  // Nets (logo is black/white — use silver)
-  CHA: '#00788C',  // Hornets teal
-  CHI: '#CE1141',  // Bulls red
-  CLE: '#FDBB30',  // Cavaliers gold (wine logo primary is too dark)
-  DAL: '#0093E9',  // Mavericks blue
-  DEN: '#FEC524',  // Nuggets gold (navy logo primary is too dark)
-  DET: '#C8102E',  // Pistons red
-  GSW: '#FFC72C',  // Warriors gold (navy logo primary is too dark)
-  HOU: '#CE1141',  // Rockets red
-  IND: '#FDBB30',  // Pacers gold (navy logo primary is too dark)
-  LAC: '#006BB6',  // Clippers blue (scores higher than red in logo)
-  LAL: '#FDB927',  // Lakers gold (purple logo primary scores lower)
-  MEM: '#5D76A9',  // Grizzlies slate blue
-  MIA: '#98002E',  // Heat red
-  MIL: '#007A33',  // Bucks green
-  MIN: '#78BE20',  // Timberwolves lime green
-  NOP: '#C8A84B',  // Pelicans gold (navy logo primary is too dark)
-  NYK: '#F58426',  // Knicks orange
-  OKC: '#007AC1',  // Thunder blue
-  ORL: '#0077C0',  // Magic blue
-  PHI: '#006BB6',  // 76ers blue
-  PHX: '#E56020',  // Suns orange
-  POR: '#E03A3E',  // Trail Blazers red
-  SAC: '#5A2D81',  // Kings purple
-  SAS: '#BBBBBB',  // Spurs (logo is silver/black — use silver)
-  TOR: '#CE1141',  // Raptors red
-  UTA: '#FFB81C',  // Jazz gold (navy logo primary is too dark)
-  WAS: '#E31837',  // Wizards red
-}
-
-function teamColor(tricode: string): string {
-  return TEAM_COLORS[tricode] ?? '#6b7280'
-}
+const { getColors } = useTeamColors()
 
 function statusLabel(game: TodayGame): string {
   if (game.status === 2) return game.status_text || 'LIVE'
@@ -152,8 +115,8 @@ function fmtPct(p: number): string {
         <div v-if="game.status !== 3 && game.away_win_pct !== null && game.home_win_pct !== null"
           class="flex items-stretch gap-1.5 flex-shrink-0">
           <div class="w-1.5 rounded-full overflow-hidden flex flex-col">
-            <div class="w-full flex-shrink-0 transition-all duration-500" :style="{ height: fmtPct(game.away_win_pct), background: teamColor(game.away_team_tricode) }"></div>
-            <div class="w-full flex-1" :style="{ background: teamColor(game.home_team_tricode) }"></div>
+            <div class="w-full flex-shrink-0 transition-all duration-500" :style="{ height: fmtPct(game.away_win_pct), background: getColors(game.away_team_tricode, game.home_team_tricode).away }"></div>
+            <div class="w-full flex-1" :style="{ background: getColors(game.away_team_tricode, game.home_team_tricode).home }"></div>
           </div>
           <div class="flex flex-col justify-between py-0.5">
             <span class="text-[10px] font-semibold tabular-nums leading-none text-white">{{ fmtPct(game.away_win_pct) }}</span>

--- a/frontend/src/composables/useTeamColors.ts
+++ b/frontend/src/composables/useTeamColors.ts
@@ -1,0 +1,27 @@
+import { ref } from 'vue'
+
+type MatchupColors = Record<string, Record<string, { away: string; home: string }>>
+
+const colors = ref<MatchupColors | null>(null)
+let fetchPromise: Promise<void> | null = null
+
+async function fetchColors(): Promise<void> {
+  const res = await fetch('/api/team-colors')
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  colors.value = await res.json()
+}
+
+export function useTeamColors() {
+  if (!fetchPromise) {
+    fetchPromise = fetchColors().catch((e) => {
+      console.error('Failed to load team colors:', e)
+      fetchPromise = null
+    })
+  }
+
+  function getColors(awayTricode: string, homeTricode: string): { away: string; home: string } {
+    return colors.value?.[awayTricode]?.[homeTricode] ?? { away: '#6b7280', home: '#6b7280' }
+  }
+
+  return { getColors }
+}


### PR DESCRIPTION
Moves `nba-team-details.json` to the backend and introduces `TeamColorsService`, which precomputes bar color pairings for all 900 possible matchups at startup.

## How colors are chosen

1. **Visibility filter** — each team's dark-mode colors (primary → secondary → tertiary) are filtered by minimum relative luminance so no color is invisible on a dark background.
2. **Hue-first pairing** — pairs are evaluated in order of increasing candidate depth (preferring primaries, changing as few colors as necessary). A pair is accepted when hue difference ≥ 30°. Saturated + gray is always accepted; gray + gray falls back to luminance contrast.
3. **Last resort** — if no pair passes the hue threshold, the highest-luminance-contrast pair is used.

Results are served via `GET /api/team-colors`; the frontend fetches once via a new `useTeamColors` composable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)