### PR TITLE
fix: prefer gamecardfeed series status over CDN schedule

### DIFF
--- a/backend/src/nba_wins_pool/services/nba_data_service.py
+++ b/backend/src/nba_wins_pool/services/nba_data_service.py
@@ -33,7 +33,7 @@ class NbaDataService:
     # Cache durations (in seconds)
     SCOREBOARD_TTL = 10  # seconds
     SCHEDULE_TTL = 24 * 60 * 60  # 24 hours
-    CURRENT_SEASON_SCHEDULE_CDN_URL = "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2_1.json"
+    CURRENT_SEASON_SCHEDULE_CDN_URL = "https://cdn.nba.com/static/json/staticData/scheduleLeagueV2.json"
     GAMECARDFEED_URL = "https://core-api.nba.com/cp/api/v1.9/feeds/gamecardfeed"
     ESPN_SEASON_URL = "https://sports.core.api.espn.com/v2/sports/basketball/leagues/nba/seasons/{year}"
     SCOREBOARD_GAME_TIME_KEY = "gameTimeUTC"
@@ -569,6 +569,7 @@ class NbaDataService:
         "away_score",
         "game_url",
         "national_broadcaster_logos",
+        "series_status_text",
     ]
 
     def _apply_live_overlay(self, game_df: pd.DataFrame, live_games: list[dict]) -> pd.DataFrame:

--- a/backend/tests/test_nba_data_service.py
+++ b/backend/tests/test_nba_data_service.py
@@ -768,6 +768,42 @@ class TestLiveFieldsOverlay:
         hist = result[result["game_id"] == "hist_game"].iloc[0]
         assert hist["status"] == NBAGameStatus.PREGAME  # unchanged from schedule
 
+    @pytest.mark.asyncio
+    async def test_gamecardfeed_series_status_overrides_schedule(self, nba_service):
+        """gamecardfeed subInfo overrides CDN schedule seriesText for series_status_text."""
+        season = nba_service.get_current_season()
+        timestamp = "2026-04-25T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("0042500151", timestamp, subInfo="BOS leads 2-1")
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "04/25/2026 00:00:00",
+            [_make_schedule_game("0042500151", timestamp, seriesText="Series tied 1-1")],
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        row = result[result["game_id"] == "0042500151"].iloc[0]
+        assert row["series_status_text"] == "BOS leads 2-1"
+
+    @pytest.mark.asyncio
+    async def test_gamecardfeed_null_series_status_falls_back_to_schedule(self, nba_service):
+        """When gamecardfeed has no subInfo, series_status_text falls back to CDN schedule seriesText."""
+        season = nba_service.get_current_season()
+        timestamp = "2026-04-25T23:00:00Z"
+        gamecardfeed_raw = _make_gamecardfeed_raw("0042500151", timestamp)  # no subInfo
+        cdn_schedule_raw = _make_schedule_raw(
+            season,
+            "04/25/2026 00:00:00",
+            [_make_schedule_game("0042500151", timestamp, seriesText="Series tied 1-1")],
+        )
+
+        with patch.object(nba_service, "_fetch_current_season_raw", return_value=(gamecardfeed_raw, cdn_schedule_raw)):
+            result = await nba_service.get_game_data(season)
+
+        row = result[result["game_id"] == "0042500151"].iloc[0]
+        assert row["series_status_text"] == "Series tied 1-1"
+
 
 class TestGameDateParsing:
     """gameDate in MM/DD/YYYY HH:MM:SS format is handled correctly."""


### PR DESCRIPTION
## Summary

- `series_status_text` (e.g. "Series tied at 1-1") was always sourced from the CDN schedule's `seriesText`, which can lag
- The live gamecardfeed carries the same data in `subInfo` and is more up-to-date
- Added `series_status_text` to `LIVE_OVERLAY_COLS` so the gamecardfeed value wins when present, falling back to the schedule when `subInfo` is absent

## Test plan

- [ ] `TestLiveFieldsOverlay::test_gamecardfeed_series_status_overrides_schedule` — gamecardfeed `subInfo` takes precedence
- [ ] `TestLiveFieldsOverlay::test_gamecardfeed_null_series_status_falls_back_to_schedule` — falls back to CDN `seriesText` when `subInfo` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)