### PR TITLE
fix: parse season from FanDuel championship market name via regex

### DIFF
--- a/backend/src/nba_wins_pool/services/nba_vegas_projections_service.py
+++ b/backend/src/nba_wins_pool/services/nba_vegas_projections_service.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -359,7 +360,8 @@ class NBAVegasProjectionsService:
                         team_data[team_name]["win_conference_prob"] = raw_prob / total
 
             elif market_type == "NBA_CHAMPIONSHIP":
-                season = market_name.removesuffix(self.CHAMPIONSHIP_SUFFIX).strip() or season
+                m = re.search(r"\d{4}-\d{2}", market_name)
+                season = m.group() if m else season
                 runners = self._active_runners(market)
                 if runners:
                     total = sum(p for _, _, p in runners)


### PR DESCRIPTION
FanDuel changed the NBA Finals Winner market name format from `{season} NBA Finals Winner` to `NBA Finals Winner {season}`, causing `removesuffix` to match nothing and pass the full market name as the season string (failing the 7-char `SeasonStr` validation).

Replaces the suffix-stripping logic with `re.search(r"\d{4}-\d{2}", market_name)` so season extraction is position-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)